### PR TITLE
Add first() method to collection.

### DIFF
--- a/src/Common/APICollection.php
+++ b/src/Common/APICollection.php
@@ -88,6 +88,16 @@ abstract class APICollection implements ArrayAccess, Countable, IteratorAggregat
     }
 
     /**
+     * Get the first item from the collection.
+     *
+     * @return APIResponse|null
+     */
+    public function first()
+    {
+        return $this->count() > 0 ? $this->items[0] : null;
+    }
+
+    /**
      * Get the total number of results in the collection (including
      * those not currently fetched from the API, if paginated).
      *


### PR DESCRIPTION
#### Changes

Rut roh, we were relying on this method from Laravel's `Collection` class but lost it when decoupling thing from the framework in v0.2. This PR adds it back in, because it's like a nice thing to have! :tada: 

References DoSomething/aurora#132.

---

For review: @angaither @weerd 
