### PR TITLE
1.0.0 rc3

### DIFF
--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -78,7 +78,8 @@ trait AuthorizesWithNorthstar
                 $token->getResourceOwnerId(),
                 $token->getToken(),
                 $token->getRefreshToken(),
-                $token->getExpires()
+                $token->getExpires(),
+                $token->getValues()['role']
             );
 
             return $token;
@@ -102,7 +103,8 @@ trait AuthorizesWithNorthstar
             $this->getOAuthRepository()->persistClientToken(
                 $this->clientId,
                 $token->getToken(),
-                $token->getExpires()
+                $token->getExpires(),
+                $token->getValues()['role']
             );
 
             return $token;
@@ -129,7 +131,8 @@ trait AuthorizesWithNorthstar
                 $token->getResourceOwnerId(),
                 $token->getToken(),
                 $token->getRefreshToken(),
-                $token->getExpires()
+                $token->getExpires(),
+                $token->getValues()['role']
             );
 
             return $token;

--- a/src/Contracts/OAuthRepositoryContract.php
+++ b/src/Contracts/OAuthRepositoryContract.php
@@ -25,9 +25,10 @@ interface OAuthRepositoryContract
      * @param $accessToken - Encoded OAuth access token
      * @param $refreshToken - Encoded OAuth refresh token
      * @param $expiration - Access token expiration as UNIX timestamp
+     * @param $role - Northstar user role
      * @return void
      */
-    public function persistUserToken($userId, $accessToken, $refreshToken, $expiration);
+    public function persistUserToken($userId, $accessToken, $refreshToken, $expiration, $role);
 
     /**
      * Save the access token for an authorized client.
@@ -35,9 +36,10 @@ interface OAuthRepositoryContract
      * @param $clientId - OAuth client ID
      * @param $accessToken - Encoded OAuth access token
      * @param $expiration - Access token expiration as UNIX timestamp
+     * @param $role - The role from the JWT
      * @return void
      */
-    public function persistClientToken($clientId, $accessToken, $expiration);
+    public function persistClientToken($clientId, $accessToken, $expiration, $role);
 
     /**
      * If a refresh token is invalid, request the user's credentials

--- a/src/Laravel/LaravelOAuthRepository.php
+++ b/src/Laravel/LaravelOAuthRepository.php
@@ -60,9 +60,9 @@ class LaravelOAuthRepository implements OAuthRepositoryContract
     public function persistUserToken($userId, $accessToken, $refreshToken, $expiration, $role)
     {
         $user = $this->createModel()->where('northstar_id', $userId)->first();
-        
+
         // If user hasn't tried to log in before, make them a local record.
-        if(! $user) {
+        if (! $user) {
             $user = $this->createModel();
             $user->northstar_id = $userId;
         }

--- a/src/Laravel/LaravelOAuthRepository.php
+++ b/src/Laravel/LaravelOAuthRepository.php
@@ -29,12 +29,11 @@ class LaravelOAuthRepository implements OAuthRepositoryContract
      */
     public function getUserToken()
     {
-        /** @var \Illuminate\Database\Eloquent\Model $user */
-        $user = app('auth')->user();
+        $user = auth()->user();
 
         // If any of the required fields are empty, return null.
         if (empty($user->northstar_id) || empty($user->access_token) ||
-            empty($user->access_token_expiration) || empty($user->refresh_token)
+            empty($user->access_token_expiration) || empty($user->refresh_token) || empty($user->role)
         ) {
             return null;
         }
@@ -44,6 +43,7 @@ class LaravelOAuthRepository implements OAuthRepositoryContract
             'access_token' => $user->access_token,
             'refresh_token' => $user->refresh_token,
             'expires' => $user->access_token_expiration,
+            'role' => $user->role,
         ]);
     }
 
@@ -54,15 +54,24 @@ class LaravelOAuthRepository implements OAuthRepositoryContract
      * @param $accessToken - Encoded OAuth access token
      * @param $refreshToken - Encoded OAuth refresh token
      * @param $expiration - Access token expiration as UNIX timestamp
+     * @param $role - Northstar user role
      * @return void
      */
-    public function persistUserToken($userId, $accessToken, $refreshToken, $expiration)
+    public function persistUserToken($userId, $accessToken, $refreshToken, $expiration, $role)
     {
         $user = $this->createModel()->where('northstar_id', $userId)->first();
+        
+        // If user hasn't tried to log in before, make them a local record.
+        if(! $user) {
+            $user = $this->createModel();
+            $user->northstar_id = $userId;
+        }
 
+        // And then update their token details.
         $user->access_token = $accessToken;
         $user->access_token_expiration = $expiration;
         $user->refresh_token = $refreshToken;
+        $user->role = $role;
 
         $user->save();
     }
@@ -74,7 +83,7 @@ class LaravelOAuthRepository implements OAuthRepositoryContract
     public function requestUserCredentials()
     {
         // Log the current user out of the application.
-        app('auth')->logout();
+        auth()->logout();
 
         // Save the intended path to redirect back after re-authenticating.
         session(['url.intended' => request()->fullUrl()]);
@@ -127,7 +136,7 @@ class LaravelOAuthRepository implements OAuthRepositoryContract
      * @param $expiration - Access token expiration as UNIX timestamp
      * @return void
      */
-    public function persistClientToken($clientId, $accessToken, $expiration)
+    public function persistClientToken($clientId, $accessToken, $expiration, $role)
     {
         app('db')->connection()
             ->table('clients')

--- a/src/Laravel/Migrations/2016_06_29_205018_add_oauth_fields_to_users.php
+++ b/src/Laravel/Migrations/2016_06_29_205018_add_oauth_fields_to_users.php
@@ -20,6 +20,8 @@ class AddOauthFieldsToUsers extends Migration
             $table->string('access_token', 1024)->nullable();
             $table->integer('access_token_expiration')->nullable();
             $table->string('refresh_token', 1024)->nullable();
+
+            $table->string('role')->nullable();
         });
     }
 
@@ -37,6 +39,7 @@ class AddOauthFieldsToUsers extends Migration
             $table->dropColumn('access_token');
             $table->dropColumn('access_token_expiration');
             $table->dropColumn('refresh_token');
+            $table->dropColumn('role');
         });
     }
 }

--- a/src/Laravel/NorthstarUserProvider.php
+++ b/src/Laravel/NorthstarUserProvider.php
@@ -44,18 +44,13 @@ class NorthstarUserProvider extends EloquentUserProvider implements UserProvider
      */
     public function retrieveByCredentials(array $credentials)
     {
-        $user = $this->northstar->getUser('username', $credentials['username']);
+        $token = $this->northstar->authorizeByPasswordGrant($credentials);
 
-        // If a matching user is found, find or create local user with that ID.
-        if (! is_null($model = $this->createModel()->where('northstar_id', $user->id)->first())) {
-            return $model;
+        if (! $token) {
+            return null;
         }
 
-        $model = $this->createModel()->newInstance();
-        $model->northstar_id = $user->id;
-        $model->save();
-
-        return $model;
+        return $this->createModel()->where('northstar_id', $token->getResourceOwnerId())->first();
     }
 
     /**
@@ -67,8 +62,7 @@ class NorthstarUserProvider extends EloquentUserProvider implements UserProvider
      */
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
-        $token = $this->northstar->authorizeByPasswordGrant($credentials);
-
-        return ! is_null($token);
+        // Is this weird? Yes.
+        return true;
     }
 }

--- a/src/NorthstarOAuthProvider.php
+++ b/src/NorthstarOAuthProvider.php
@@ -120,6 +120,7 @@ class NorthstarOAuthProvider extends AbstractProvider
     {
         $jwt = (new Parser())->parse($result['access_token']);
         $result['resource_owner_id'] = $jwt->getClaim('sub');
+        $result['role'] = $jwt->getClaim('role');
 
         return $result;
     }


### PR DESCRIPTION
#### Changes

Closes #17.

This PR updates Northstar-PHP to automatically parse and store the user's role when it's returned as part of the access token (DoSomething/northstar#375). This allows client applications to automatically use the user role stored in Northstar rather than having to duplicate that logic everywhere.

By using the `role:admin` or `role:staff` scope (DoSomething/northstar#382), this also allows apps like Aurora can request a token that can _only_ be used by users with those Northstar roles. So Aurora is no longer responsible for acting as the gatekeeper for allowing people to view/edit user records! It'll check the access token to see if a user is authorized so it can show a pretty error screen, but even if the user got hold of their token it wouldn't grant them any additional privileges they didn't already have.

This pull request aaaaaalso changes the included user provider to verify credentials within the `retrieveByCredentials` method, since it was otherwise stuck making two HTTP requests which is kinda crummy. TBH, it might make more sense to just have a custom `NorthstarAuth` class to handle all this rather than trying to fit it into the user provider contract, but idk. That's for a future PR (#18). 😆

---

For review: @weerd @angaither 
