### PR TITLE
V1.0.0 rc4

### DIFF
--- a/src/Common/RestApiClient.php
+++ b/src/Common/RestApiClient.php
@@ -117,7 +117,7 @@ class RestApiClient
      */
     public function delete($path, $withAuthorization = true)
     {
-        $response = $this->send('DELETE', $path, $withAuthorization);
+        $response = $this->send('DELETE', $path, [], $withAuthorization);
 
         return $this->responseSuccessful($response);
     }

--- a/src/Common/RestApiClient.php
+++ b/src/Common/RestApiClient.php
@@ -126,11 +126,11 @@ class RestApiClient
      * Get the authorization header for a request, if needed.
      * @see AuthorizesWithNorthstar
      *
-     * @return string|null
+     * @return array
      */
     protected function getAuthorizationHeader()
     {
-        return null;
+        return [];
     }
 
     /**
@@ -222,12 +222,12 @@ class RestApiClient
     {
         // By default, we append the authorization header to every request.
         if ($withAuthorization) {
-            $headers = $this->getAuthorizationHeader();
+            $authorizationHeader = $this->getAuthorizationHeader();
             if (empty($options['headers'])) {
                 $options['headers'] = [];
             }
 
-            $options['headers'] = array_merge($options['headers'], $headers);
+            $options['headers'] = array_merge($options['headers'], $authorizationHeader);
         }
 
         return $this->client->request($method, $path, $options);

--- a/src/Laravel/LaravelNorthstar.php
+++ b/src/Laravel/LaravelNorthstar.php
@@ -2,14 +2,14 @@
 
 namespace DoSomething\Northstar\Laravel;
 
-use DoSomething\Northstar\NorthstarClient;
+use DoSomething\Northstar\Northstar;
 use DoSomething\Northstar\Exceptions\InternalException;
 use DoSomething\Northstar\Exceptions\ValidationException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Contracts\Validation\ValidationException as LaravelValidationException;
 use Illuminate\Support\MessageBag;
 
-class LaravelNorthstarClient extends NorthstarClient
+class LaravelNorthstar extends Northstar
 {
     /**
      * The class name of the OAuth repository. For Laravel, we default to the included repository

--- a/src/Laravel/NorthstarServiceProvider.php
+++ b/src/Laravel/NorthstarServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace DoSomething\Northstar\Laravel;
 
-use DoSomething\Northstar\NorthstarClient;
+use DoSomething\Northstar\Northstar;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Application;
@@ -27,8 +27,8 @@ class NorthstarServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(NorthstarClient::class, function () {
-            return new LaravelNorthstarClient(config('services.northstar'));
+        $this->app->singleton(Northstar::class, function () {
+            return new LaravelNorthstar(config('services.northstar'));
         });
 
         // Register the custom user provider.
@@ -41,7 +41,7 @@ class NorthstarServiceProvider extends ServiceProvider
         });
 
         // Set alias for facade / requesting from app() helper.
-        $this->app->alias(NorthstarClient::class, 'northstar');
+        $this->app->alias(Northstar::class, 'northstar');
     }
 
     /**

--- a/src/Laravel/NorthstarUserProvider.php
+++ b/src/Laravel/NorthstarUserProvider.php
@@ -2,7 +2,7 @@
 
 namespace DoSomething\Northstar\Laravel;
 
-use DoSomething\Northstar\NorthstarClient;
+use DoSomething\Northstar\Northstar;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Auth\EloquentUserProvider;
@@ -12,18 +12,18 @@ class NorthstarUserProvider extends EloquentUserProvider implements UserProvider
 {
     /**
      * The Northstar API client.
-     * @var NorthstarClient
+     * @var Northstar
      */
     protected $northstar;
 
     /**
      * Create a new Northstar user provider.
      *
-     * @param  \DoSomething\Northstar\NorthstarClient $northstar
+     * @param  \DoSomething\Northstar\Northstar $northstar
      * @param  \Illuminate\Contracts\Hashing\Hasher $hasher
      * @param  string $model
      */
-    public function __construct(NorthstarClient $northstar, HasherContract $hasher, $model)
+    public function __construct(Northstar $northstar, HasherContract $hasher, $model)
     {
         $this->northstar = $northstar;
 

--- a/src/Northstar.php
+++ b/src/Northstar.php
@@ -3,12 +3,12 @@
 namespace DoSomething\Northstar;
 
 use DoSomething\Northstar\Common\RestApiClient;
-use DoSomething\Northstar\Resources\NorthstarKey;
+use DoSomething\Northstar\Resources\NorthstarClient;
 use DoSomething\Northstar\Resources\NorthstarUser;
 use DoSomething\Northstar\Resources\NorthstarUserCollection;
-use DoSomething\Northstar\Resources\NorthstarKeyCollection;
+use DoSomething\Northstar\Resources\NorthstarClientCollection;
 
-class NorthstarClient extends RestApiClient
+class Northstar extends RestApiClient
 {
     use AuthorizesWithNorthstar;
 
@@ -114,11 +114,11 @@ class NorthstarClient extends RestApiClient
      *
      * @return array - keys
      */
-    public function getAllApiKeys()
+    public function getAllClients()
     {
         $response = $this->get('v1/keys');
 
-        return new NorthstarKeyCollection($response);
+        return new NorthstarClientCollection($response);
     }
 
     /**
@@ -126,54 +126,54 @@ class NorthstarClient extends RestApiClient
      * Requires an `admin` scoped API key.
      *
      * @param array $input - key values
-     * @return NorthstarKey
+     * @return Northstar
      */
-    public function createNewApiKey($input)
+    public function createNewClient($input)
     {
-        $response = $this->post('v1/keys', $input);
+        $response = $this->post('v2/clients', $input);
 
-        return new NorthstarKey($response['data']);
+        return new NorthstarClient($response['data']);
     }
 
     /**
      * Send a GET request to get the specified key.
      * Requires an `admin` scoped API key.
      *
-     * @param string $api_key - API key
-     * @return NorthstarKey
+     * @param string $client_id - API key
+     * @return Northstar
      */
-    public function getApiKey($api_key)
+    public function getClient($client_id)
     {
-        $response = $this->get('v1/keys/'.$api_key);
+        $response = $this->get('v2/clients/'.$client_id);
 
-        return new NorthstarKey($response['data']);
+        return new NorthstarClient($response['data']);
     }
 
     /**
      * Send a POST request to generate new keys to northstar
      * Requires an `admin` scoped API key.
      *
-     * @param string $api_key - API key
+     * @param string $client_id - API key
      * @param array $input - key values
-     * @return NorthstarKey
+     * @return Northstar
      */
-    public function updateApiKey($api_key, $input)
+    public function updateClient($client_id, $input)
     {
-        $response = $this->put('v1/keys/'.$api_key, $input);
+        $response = $this->put('v2/clients/'.$client_id, $input);
 
-        return new NorthstarKey($response['data']);
+        return new NorthstarClient($response['data']);
     }
 
     /**
      * Send a DELETE request to delete an API key from Northstar.
      * Requires an `admin` scoped API key.
      *
-     * @param string $api_key - API key
+     * @param string $client_id - API key
      * @return bool - Whether user was successfully deleted
      */
-    public function deleteApiKey($api_key)
+    public function deleteClient($client_id)
     {
-        return $this->delete('v1/keys/'.$api_key);
+        return $this->delete('v2/clients/'.$client_id);
     }
 
     /**

--- a/src/Resources/NorthstarClient.php
+++ b/src/Resources/NorthstarClient.php
@@ -4,7 +4,7 @@ namespace DoSomething\Northstar\Resources;
 
 use DoSomething\Northstar\Common\APIResponse;
 
-class NorthstarKey extends APIResponse
+class NorthstarClient extends APIResponse
 {
-    // major key
+    // OAuth 2 client
 }

--- a/src/Resources/NorthstarClientCollection.php
+++ b/src/Resources/NorthstarClientCollection.php
@@ -4,10 +4,10 @@ namespace DoSomething\Northstar\Resources;
 
 use DoSomething\Northstar\Common\APICollection;
 
-class NorthstarKeyCollection extends APICollection
+class NorthstarClientCollection extends APICollection
 {
     public function __construct($response)
     {
-        parent::__construct($response, NorthstarKey::class);
+        parent::__construct($response, NorthstarClient::class);
     }
 }


### PR DESCRIPTION
#### Changes

Moooore changes. 😩 

🔤 This PR renames `NorthstarClient` to `Northstar` for the base HTTP client, because we need to use `NorthstarClient` as the resource class name (for the objects returned from `v2/clients` route).

💻 It also updates the OAuth client methods to use the new `v2/clients` endpoints rather than the old API key ones.

🎧 Finally, just some tidying up of the authorization header methods (for example, not returning null when we don't have to). And fixes a mis-aligned argument in the `delete()` HTTP method.

---

For review: @weerd 
