### PR TITLE
Fix incorrect constructor call.

### DIFF
--- a/src/NorthstarOAuthProvider.php
+++ b/src/NorthstarOAuthProvider.php
@@ -32,7 +32,7 @@ class NorthstarOAuthProvider extends AbstractProvider
     {
         $this->url = $options['url'];
 
-        parent::_construct($options, $collaborators);
+        parent::__construct($options, $collaborators);
     }
 
     /**


### PR DESCRIPTION
#### Changes

Haven't the slightest how this happened. Somehow the copy of the oauth2-client `AbstractProvider` on my local when I was developing this had a `_construct` method instead of `__construct`, and the version that got installed on QA (and my local after re-installing) has the normal double-underscored version. Weeeeeeeeird.

---

For review: @weerd 
