### PR TITLE
More little fixes.

### DIFF
--- a/src/Common/RestApiClient.php
+++ b/src/Common/RestApiClient.php
@@ -20,6 +20,13 @@ class RestApiClient
     protected $client;
 
     /**
+     * Default headers applied to every request.
+     *
+     * @var array
+     */
+    protected $defaultHeaders;
+
+    /**
      * The number of times a request has been attempted.
      *
      * @var int
@@ -33,7 +40,7 @@ class RestApiClient
      */
     public function __construct($url)
     {
-        $standardHeaders = [
+        $this->defaultHeaders = [
             'Content-Type' => 'application/json',
             'Accept' => 'application/json',
         ];
@@ -41,7 +48,7 @@ class RestApiClient
         $client = new Client([
             'base_uri' => $url,
             'defaults' => [
-                'headers' => $standardHeaders,
+                'headers' => $this->defaultHeaders,
             ],
         ]);
 
@@ -227,7 +234,7 @@ class RestApiClient
                 $options['headers'] = [];
             }
 
-            $options['headers'] = array_merge($options['headers'], $authorizationHeader);
+            $options['headers'] = array_merge($this->defaultHeaders, $options['headers'], $authorizationHeader);
         }
 
         return $this->client->request($method, $path, $options);

--- a/src/Northstar.php
+++ b/src/Northstar.php
@@ -112,11 +112,11 @@ class Northstar extends RestApiClient
      * Send a GET request to return all Northstar keys.
      * Requires an `admin` scoped API key.
      *
-     * @return array - keys
+     * @return NorthstarClientCollection
      */
     public function getAllClients()
     {
-        $response = $this->get('v1/keys');
+        $response = $this->get('v2/clients');
 
         return new NorthstarClientCollection($response);
     }
@@ -126,7 +126,7 @@ class Northstar extends RestApiClient
      * Requires an `admin` scoped API key.
      *
      * @param array $input - key values
-     * @return Northstar
+     * @return NorthstarClient
      */
     public function createNewClient($input)
     {
@@ -140,7 +140,7 @@ class Northstar extends RestApiClient
      * Requires an `admin` scoped API key.
      *
      * @param string $client_id - API key
-     * @return Northstar
+     * @return NorthstarClient
      */
     public function getClient($client_id)
     {
@@ -155,7 +155,7 @@ class Northstar extends RestApiClient
      *
      * @param string $client_id - API key
      * @param array $input - key values
-     * @return Northstar
+     * @return NorthstarClient
      */
     public function updateClient($client_id, $input)
     {


### PR DESCRIPTION
#### Changes

🗿 Fixes issue where the default request headers (`Accept: application/json` and `Content-Type: application/json`) would be discarded when setting the `Authorization` header for a request. This is because Guzzle only applies the values set in the `defaults` array when the request doesn't have a value for that option.

💻 Use the `v2/clients` endpoint rather than `v1/keys` for listing OAuth clients. Also fixes two incorrect docblocks for method return types.

---

For review: @angaither 
