### PR TITLE
adds bug fixes for laravel 5.2

### DIFF
--- a/src/Laravel/NorthstarServiceProvider.php
+++ b/src/Laravel/NorthstarServiceProvider.php
@@ -65,7 +65,7 @@ class NorthstarServiceProvider extends ServiceProvider
      */
     public function registerProviderForNewLaravel(AuthManager $auth)
     {
-        $auth->provider('northstar', function ($app, array $config) {
+        $auth->provider('northstar', function ($app) {
             return new \DoSomething\Northstar\Laravel\NorthstarUserProvider(
                 $app['northstar'], $app['hash'], config('auth.providers.users.model')
             );

--- a/src/Laravel/NorthstarServiceProvider.php
+++ b/src/Laravel/NorthstarServiceProvider.php
@@ -33,7 +33,7 @@ class NorthstarServiceProvider extends ServiceProvider
 
         // Register the custom user provider.
         $this->app->resolving('auth', function (AuthManager $auth) {
-            if (method_exists($auth, 'provide')) {
+            if (method_exists($auth, 'provider')) {
                 return $this->registerProviderForNewLaravel($auth);
             }
 
@@ -65,9 +65,9 @@ class NorthstarServiceProvider extends ServiceProvider
      */
     public function registerProviderForNewLaravel(AuthManager $auth)
     {
-        $auth->provide('northstar', function ($app, array $config) {
+        $auth->provider('northstar', function ($app, array $config) {
             return new \DoSomething\Northstar\Laravel\NorthstarUserProvider(
-                $app['northstar'], $app['hash'], $config['auth.model']
+                $app['northstar'], $app['hash'], $config['auth.providers.users.model']
             );
         });
     }

--- a/src/Laravel/NorthstarServiceProvider.php
+++ b/src/Laravel/NorthstarServiceProvider.php
@@ -67,7 +67,7 @@ class NorthstarServiceProvider extends ServiceProvider
     {
         $auth->provider('northstar', function ($app, array $config) {
             return new \DoSomething\Northstar\Laravel\NorthstarUserProvider(
-                $app['northstar'], $app['hash'], $config['auth.providers.users.model']
+                $app['northstar'], $app['hash'], config('auth.providers.users.model')
             );
         });
     }


### PR DESCRIPTION
Fixes typo from `provide` to `provider` and correct `$config` path in NorthstarServiceProvider.php. 
