### PR TITLE
Add support for switching grant per request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,21 @@ and retrieving tokens.
 use DoSomething\Northstar\Northstar;
 
 $northstar = new Northstar([
-    'grant' => 'client_credentials', // OAuth grant to use: either 'password' or 'client_credentials'
+    'grant' => 'client_credentials', // Default OAuth grant to use: either 'password' or 'client_credentials'
     'url' => 'https://northstar.dosomething.org', // the environment you want to connect to
-    'client_id' => 'example', // your app's client ID
-    'client_secret' => 'xxxxxxxxxxxxx', // your app's client secret
-    'scope' => ['user'], // the scopes to request  
     'repository' => \YourApp\OAuthRepository::class, // class which handles saving/retrieving tokens
+    
+    // Then, configure client ID, client secret, and scopes per grant.
+    'client_credentials' => [
+        'client_id' => 'example',
+        'client_secret' => 'xxxxxxxxxxxxx',
+        'scope' => ['user'],
+    ],
+    'password' => [
+        'client_id' => 'example',
+        'client_secret' => 'xxxxxxxxxxxxx',
+        'scope' => ['user'],
+    ],
 ]);
 
 // And go!
@@ -62,11 +71,21 @@ Then, set your environment & key in `config/services.php`:
 
 ```php
 'northstar' => [
-    'grant' => 'client_credentials', // OAuth grant to use: either 'password' or 'client_credentials'
+    'grant' => 'client_credentials', // Default OAuth grant to use: either 'password' or 'client_credentials'
     'url' => 'https://northstar.dosomething.org', // the environment you want to connect to
-    'client_id' => 'example', // your app's client ID
-    'client_secret' => 'xxxxxxxxxxxxx', // your app's client secret
-    'scope' => ['user', 'admin'], // the scopes to request  
+    'repository' => \YourApp\OAuthRepository::class, // class which handles saving/retrieving tokens
+    
+    // Then, configure client ID, client secret, and scopes per grant.
+    'client_credentials' => [
+        'client_id' => 'example',
+        'client_secret' => 'xxxxxxxxxxxxx',
+        'scope' => ['user'],
+    ],
+    'password' => [
+        'client_id' => 'example',
+        'client_secret' => 'xxxxxxxxxxxxx',
+        'scope' => ['user'],
+    ],
 ]
 ```
 

--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -251,11 +251,12 @@ trait AuthorizesWithNorthstar
     protected function getAuthorizationServer()
     {
         if (! $this->authorizationServer) {
+            $config = $this->config[$this->grant];
             $this->authorizationServer = new NorthstarOAuthProvider([
                 'url' => $this->authorizationServerUri,
-                'clientId' => $this->config[$this->grant]['client_id'],
-                'clientSecret' => $this->config[$this->grant]['client_secret'],
-                'redirectUri' => $this->config[$this->grant]['redirect_uri'],
+                'clientId' => $config['client_id'],
+                'clientSecret' => $config['client_secret'],
+                'redirectUri' => ! empty($config['redirect_uri']) ? $config['redirect_uri'] : null,
             ]);
         }
 

--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -10,40 +10,26 @@ use League\OAuth2\Client\Token\AccessToken;
 trait AuthorizesWithNorthstar
 {
     /**
-     * The grant to use for authorization: supported values are either
-     * 'password' or 'client_credentials'.
-     *
-     * @var string
-     */
-    protected $grant = 'password';
-
-    /**
-     * The OAuth2 client ID.
-     *
-     * @var string
-     */
-    protected $clientId;
-
-    /**
-     * The OAuth2 client secret.
-     *
-     * @var string
-     */
-    protected $clientSecret;
-
-    /**
-     * OAuth scopes to request.
-     *
-     * @var array
-     */
-    protected $scope = ['user'];
-
-    /**
      * The authorization server URL (for example, Northstar).
      *
      * @var string
      */
-    protected $authorizationServerUrl;
+    protected $authorizationServerUri;
+
+    /**
+     * The grant to use for authorization: supported values are either
+     * 'password' or 'client_credentials'. // @TODO: Add 'authorization_code'!
+     *
+     * @var string
+     */
+    protected $grant;
+
+    /**
+     * The OAuth2 configuration array, keyed by grant name.
+     *
+     * @var string
+     */
+    protected $config;
 
     /**
      * The class name of the OAuth repository.
@@ -53,7 +39,7 @@ trait AuthorizesWithNorthstar
     protected $repository;
 
     /**
-     * The authorization server.
+     * The league/oauth2-client authorization server.
      *
      * @var NorthstarOAuthProvider
      */
@@ -71,7 +57,7 @@ trait AuthorizesWithNorthstar
             $token = $this->getAuthorizationServer()->getAccessToken('password', [
                 'username' => $credentials['username'],
                 'password' => $credentials['password'],
-                'scope' => $this->scope,
+                'scope' => $this->config['password']['scope'],
             ]);
 
             $this->getOAuthRepository()->persistUserToken(
@@ -97,11 +83,11 @@ trait AuthorizesWithNorthstar
     {
         try {
             $token = $this->getAuthorizationServer()->getAccessToken('client_credentials', [
-                'scope' => $this->scope,
+                'scope' => $this->config['client_credentials']['scope'],
             ]);
 
             $this->getOAuthRepository()->persistClientToken(
-                $this->clientId,
+                $this->config['client_credentials']['client_id'],
                 $token->getToken(),
                 $token->getExpires(),
                 $token->getValues()['role']
@@ -124,7 +110,7 @@ trait AuthorizesWithNorthstar
         try {
             $token = $this->getAuthorizationServer()->getAccessToken('refresh_token', [
                 'refresh_token' => $oldToken->getRefreshToken(),
-                'scope' => $this->scope,
+                'scope' => $this->config[$this->grant]['scope'],
             ]);
 
             $this->getOAuthRepository()->persistUserToken(
@@ -166,7 +152,7 @@ trait AuthorizesWithNorthstar
     public function invalidateRefreshToken(AccessToken $token)
     {
         $this->getAuthorizationServer()->getAuthenticatedRequest('DELETE',
-            $this->authorizationServerUrl . '/v2/auth/token', $token, [
+            $this->authorizationServerUri . '/v2/auth/token', $token, [
                 'json' => [
                     'token' => $token->getRefreshToken(),
                 ],
@@ -266,10 +252,10 @@ trait AuthorizesWithNorthstar
     {
         if (! $this->authorizationServer) {
             $this->authorizationServer = new NorthstarOAuthProvider([
-                'url' => $this->authorizationServerUrl,
-                'clientId' => $this->clientId,
-                'clientSecret' => $this->clientSecret,
-                'redirectUri' => '', // @TODO: Add this once we support auth code grant.
+                'url' => $this->authorizationServerUri,
+                'clientId' => $this->config[$this->grant]['client_id'],
+                'clientSecret' => $this->config[$this->grant]['client_secret'],
+                'redirectUri' => $this->config[$this->grant]['redirect_uri'],
             ]);
         }
 

--- a/src/Common/RestApiClient.php
+++ b/src/Common/RestApiClient.php
@@ -69,10 +69,7 @@ class RestApiClient
             'query' => $query,
         ];
 
-        $response = $this->send('GET', $path, $options, $withAuthorization);
-        $body = $response->getBody()->getContents();
-
-        return is_null($response) ? null : json_decode($body, true);
+        return $this->send('GET', $path, $options, $withAuthorization);
     }
 
     /**
@@ -89,10 +86,7 @@ class RestApiClient
             'json' => $payload,
         ];
 
-        $response = $this->send('POST', $path, $options, $withAuthorization);
-        $body = $response->getBody()->getContents();
-
-        return is_null($response) ? null : json_decode($body, true);
+        return $this->send('POST', $path, $options, $withAuthorization);
     }
 
     /**
@@ -109,10 +103,7 @@ class RestApiClient
             'json' => $payload,
         ];
 
-        $response = $this->send('PUT', $path, $options, $withAuthorization);
-        $body = $response->getBody()->getContents();
-
-        return is_null($response) ? null : json_decode($body, true);
+        return $this->send('PUT', $path, $options, $withAuthorization);
     }
 
     /**
@@ -183,7 +174,7 @@ class RestApiClient
             // Reset the number of attempts back to zero once we've had a successful response!
             $this->attempts = 0;
 
-            return $response;
+            return json_decode($response->getBody()->getContents(), true);
         } catch (\GuzzleHttp\Exception\ClientException $e) {
             $endpoint = strtoupper($method).' '.$path;
             $response = json_decode($e->getResponse()->getBody()->getContents());
@@ -243,14 +234,11 @@ class RestApiClient
     /**
      * Determine if the response was successful or not.
      *
-     * @param $response
+     * @param array $json
      * @return bool
      */
-    public function responseSuccessful(Response $response)
+    public function responseSuccessful(array $json)
     {
-        $body = $response->getBody()->getContents();
-        $json = json_decode($body, true);
-
         return ! empty($json['success']);
     }
 

--- a/src/Laravel/Migrations/2016_06_29_205018_create_oauth_client_table.php
+++ b/src/Laravel/Migrations/2016_06_29_205018_create_oauth_client_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateOAuthClientTable extends Migration
+class CreateOauthClientTable extends Migration
 {
     /**
      * Run the migrations.

--- a/src/Northstar.php
+++ b/src/Northstar.php
@@ -21,11 +21,9 @@ class Northstar extends RestApiClient
         $base_url = $config['url'];
 
         // Set required fields for OAuth authentication trait.
-        $this->authorizationServerUrl = $config['url'];
-        $this->grant = ! empty($config['grant']) ? $config['grant'] : 'client_credentials';
-        $this->clientId = $config['client_id'];
-        $this->clientSecret = $config['client_secret'];
-        $this->scope = isset($config['scope']) ? $config['scope'] : ['user'];
+        $this->authorizationServerUri = $config['url'];
+        $this->grant = $config['grant'];
+        $this->config = $config;
 
         if (! empty($config['repository'])) {
             $this->repository = $config['repository'];


### PR DESCRIPTION
#### Changes

This pull request adds separate configuration per grant, so an application could use elevated privileges for "background" tasks using the `client_credentials` grant, while still making requests on behalf of authorized users via the `password` grant.

I also snuck in a fix for #24. (5981593)
#### How should this be reviewed?

Check out the diff! I didn't add methods to switch grant on-the-fly yet.

---

For review: @weerd 
