### PR TITLE
Add methods to swap which grant is used per request.

### DIFF
--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -158,6 +158,29 @@ trait AuthorizesWithNorthstar
     }
 
     /**
+     * Specify which grant is used for this request.
+     *
+     * @param $grant
+     * @return $this
+     */
+    public function usingGrant($grant)
+    {
+        $this->grant = $grant;
+
+        return $this;
+    }
+
+    /**
+     * Specify that the current request should use the client credentials grant.
+     *
+     * @return $this
+     */
+    public function asClient()
+    {
+        return $this->usingGrant('client_credentials');
+    }
+
+    /**
      * Get the access token from the repository based on the chosen grant.
      *
      * @return mixed
@@ -271,5 +294,16 @@ trait AuthorizesWithNorthstar
         }
 
         return new $this->repository();
+    }
+
+    /**
+     * Clean up after a request is sent.
+     *
+     * @return void
+     */
+    protected function cleanUp()
+    {
+        // Reset back to the default grant.
+        $this->grant = $this->config['grant'];
     }
 }

--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -46,6 +46,27 @@ trait AuthorizesWithNorthstar
     private $authorizationServer;
 
     /**
+     * Authorize a machine based on the given client credentials.
+     *
+     * @return mixed
+     */
+    public function authorizeByClientCredentialsGrant()
+    {
+        $token = $this->getAuthorizationServer()->getAccessToken('client_credentials', [
+            'scope' => $this->config['client_credentials']['scope'],
+        ]);
+
+        $this->getOAuthRepository()->persistClientToken(
+            $this->config['client_credentials']['client_id'],
+            $token->getToken(),
+            $token->getExpires(),
+            $token->getValues()['role']
+        );
+
+        return $token;
+    }
+
+    /**
      * Authorize a user based on the given username & password.
      *
      * @param array $credentials
@@ -64,31 +85,6 @@ trait AuthorizesWithNorthstar
                 $token->getResourceOwnerId(),
                 $token->getToken(),
                 $token->getRefreshToken(),
-                $token->getExpires(),
-                $token->getValues()['role']
-            );
-
-            return $token;
-        } catch (IdentityProviderException $e) {
-            return null;
-        }
-    }
-
-    /**
-     * Authorize a machine based on the given client credentials.
-     *
-     * @return mixed
-     */
-    public function authorizeByClientCredentialsGrant()
-    {
-        try {
-            $token = $this->getAuthorizationServer()->getAccessToken('client_credentials', [
-                'scope' => $this->config['client_credentials']['scope'],
-            ]);
-
-            $this->getOAuthRepository()->persistClientToken(
-                $this->config['client_credentials']['client_id'],
-                $token->getToken(),
                 $token->getExpires(),
                 $token->getValues()['role']
             );

--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -171,13 +171,21 @@ trait AuthorizesWithNorthstar
     }
 
     /**
-     * Specify that the current request should use the client credentials grant.
+     * Specify that the next request should use the client credentials grant.
      *
      * @return $this
      */
     public function asClient()
     {
         return $this->usingGrant('client_credentials');
+    }
+
+    /**
+     * Specify that the next request should use the password grant.
+     */
+    public function asUser()
+    {
+        return $this->usingGrant('password');
     }
 
     /**

--- a/src/Common/RestApiClient.php
+++ b/src/Common/RestApiClient.php
@@ -132,6 +132,17 @@ class RestApiClient
     }
 
     /**
+     * Clean up after a request is sent.
+     * @see AuthorizesWithNorthstar
+     *
+     * @return void
+     */
+    protected function cleanUp()
+    {
+        // ...
+    }
+
+    /**
      * Handle unauthorized exceptions.
      *
      * @param string $endpoint - The human-readable route that triggered the error.
@@ -171,8 +182,10 @@ class RestApiClient
             // Make the request. Any error code will send us to the 'catch' below.
             $response = $this->raw($method, $path, $options, $withAuthorization);
 
-            // Reset the number of attempts back to zero once we've had a successful response!
+            // Reset the number of attempts back to zero once we've had a successful
+            // response, and then perform any other clean-up.
             $this->attempts = 0;
+            $this->cleanUp();
 
             return json_decode($response->getBody()->getContents(), true);
         } catch (\GuzzleHttp\Exception\ClientException $e) {


### PR DESCRIPTION
#### Changes

This pull request adds methods to specify which grant is used per request (either `asClient()` to make request with the client credentials, or `asUser()` to make the request using the current user's token). 

I have some more changes I'm working on, but holding those off for another PR! 😉
#### How should this be reviewed?

Check out the changes and make sure they seem okay! See commit titles for context.

---

For review: @weerd 
