### PR TITLE
Add NorthstarUser interface and trait.

### DIFF
--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -81,13 +81,7 @@ trait AuthorizesWithNorthstar
                 'scope' => $this->config['password']['scope'],
             ]);
 
-            $this->getOAuthRepository()->persistUserToken(
-                $token->getResourceOwnerId(),
-                $token->getToken(),
-                $token->getRefreshToken(),
-                $token->getExpires(),
-                $token->getValues()['role']
-            );
+            $this->getOAuthRepository()->persistUserToken($token);
 
             return $token;
         } catch (IdentityProviderException $e) {
@@ -109,13 +103,7 @@ trait AuthorizesWithNorthstar
                 'scope' => $this->config[$this->grant]['scope'],
             ]);
 
-            $this->getOAuthRepository()->persistUserToken(
-                $token->getResourceOwnerId(),
-                $token->getToken(),
-                $token->getRefreshToken(),
-                $token->getExpires(),
-                $token->getValues()['role']
-            );
+            $this->getOAuthRepository()->persistUserToken($token);
 
             return $token;
         } catch (IdentityProviderException $e) {
@@ -154,7 +142,8 @@ trait AuthorizesWithNorthstar
                 ],
             ]);
 
-        $this->getOAuthRepository()->removeUserToken($token->getResourceOwnerId());
+        $user = $this->getOAuthRepository()->getUser($token->getResourceOwnerId());
+        $user->clearOAuthToken();
     }
 
     /**

--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -25,6 +25,13 @@ trait AuthorizesWithNorthstar
     protected $grant;
 
     /**
+     * A queued access token to use for the next request.
+     *
+     * @var AccessToken|null
+     */
+    protected $token;
+
+    /**
      * The OAuth2 configuration array, keyed by grant name.
      *
      * @var string
@@ -171,6 +178,8 @@ trait AuthorizesWithNorthstar
 
     /**
      * Specify that the next request should use the password grant.
+     *
+     * @return $this
      */
     public function asUser()
     {
@@ -178,19 +187,43 @@ trait AuthorizesWithNorthstar
     }
 
     /**
+     * Make request using the provided access token (for example, to make
+     * a request to another service in order to complete an API request).
+     *
+     * @param AccessToken $token
+     * @return $this
+     */
+    public function withToken(AccessToken $token)
+    {
+        $this->grant = 'provided_token';
+        $this->token = $token;
+
+        return $this;
+    }
+
+    /**
      * Get the access token from the repository based on the chosen grant.
      *
-     * @return mixed
+     * @return AccessToken|null
      * @throws \Exception
      */
     protected function getAccessToken()
     {
         switch ($this->grant) {
+            case 'provided_token':
+                return $this->token;
+
             case 'client_credentials':
                 return $this->getOAuthRepository()->getClientToken();
 
             case 'password':
-                return $this->getOAuthRepository()->getUserToken();
+                $user = $this->getOAuthRepository()->getCurrentUser();
+
+                if (! $user) {
+                    return null;
+                }
+
+                return $user->getOAuthToken();
 
             default:
                 throw new \Exception('Unsupported grant type. Check $this->grant.');
@@ -207,6 +240,9 @@ trait AuthorizesWithNorthstar
     protected function refreshAccessToken($token)
     {
         switch ($this->grant) {
+            case 'provided_token':
+                throw new UnauthorizedException('[internal]', 'The provided token expired.');
+
             case 'client_credentials':
                 return $this->authorizeByClientCredentialsGrant();
 
@@ -300,7 +336,8 @@ trait AuthorizesWithNorthstar
      */
     protected function cleanUp()
     {
-        // Reset back to the default grant.
+        // Reset back to the default grant & empty any provided token.
         $this->grant = $this->config['grant'];
+        $this->token = null;
     }
 }

--- a/src/Contracts/NorthstarUserContract.php
+++ b/src/Contracts/NorthstarUserContract.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace DoSomething\Northstar\Contracts;
+
+use League\OAuth2\Client\Token\AccessToken;
+
+interface NorthstarUserContract
+{
+    /**
+     * Get the Northstar ID for the user.
+     *
+     * @return string|null
+     */
+    public function getNorthstarIdentifier();
+
+    /**
+     * Save the Northstar ID for the user.
+     *
+     * @return void
+     */
+    public function setNorthstarIdentifier($id);
+
+    /**
+     * Get the access token for the user.
+     *
+     * @return AccessToken|null
+     */
+    public function getOAuthToken();
+
+    /**
+     * Save the access token for the user.
+     *
+     * @param AccessToken $token
+     * @return void
+     */
+    public function setOAuthToken(AccessToken $token);
+
+    /**
+     * Clear the access token for the user.
+     *
+     * @return void
+     */
+    public function clearOAuthToken();
+}

--- a/src/Contracts/OAuthRepositoryContract.php
+++ b/src/Contracts/OAuthRepositoryContract.php
@@ -2,14 +2,32 @@
 
 namespace DoSomething\Northstar\Contracts;
 
+use League\OAuth2\Client\Token\AccessToken;
+
 interface OAuthRepositoryContract
 {
     /**
+     * Get the ID of the logged-in user.
+     *
+     * @return NorthstarUserContract|null
+     */
+    public function getCurrentUser();
+
+    /**
+     * Get a user by their Northstar ID.
+     *
+     * @return NorthstarUserContract|null
+     */
+    public function getUser($id);
+
+    /**
      * Get the given authenticated user's access token.
+     *
+     * @param NorthstarUserContract $user
      *
      * @return \League\OAuth2\Client\Token\AccessToken|null
      */
-    public function getUserToken();
+    public function getUserToken(NorthstarUserContract $user);
 
     /**
      * Get the OAuth client's token.
@@ -21,14 +39,10 @@ interface OAuthRepositoryContract
     /**
      * Save the access & refresh tokens for an authorized user.
      *
-     * @param $userId - Northstar user ID
-     * @param $accessToken - Encoded OAuth access token
-     * @param $refreshToken - Encoded OAuth refresh token
-     * @param $expiration - Access token expiration as UNIX timestamp
-     * @param $role - Northstar user role
-     * @return void
+     * @param \League\OAuth2\Client\Token\AccessToken $token
+     * @internal param $userId - Northstar user ID
      */
-    public function persistUserToken($userId, $accessToken, $refreshToken, $expiration, $role);
+    public function persistUserToken(AccessToken $token);
 
     /**
      * Save the access token for an authorized client.
@@ -46,11 +60,4 @@ interface OAuthRepositoryContract
      * by redirecting to the login screen.
      */
     public function requestUserCredentials();
-
-    /**
-     * Remove the user's token information when they log out.
-     *
-     * @param $userId - Northstar user ID
-     */
-    public function removeUserToken($userId);
 }

--- a/src/Laravel/HasNorthstarToken.php
+++ b/src/Laravel/HasNorthstarToken.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace DoSomething\Northstar\Laravel;
+
+use League\OAuth2\Client\Token\AccessToken;
+
+/**
+ * @property string $northstar_id
+ * @property string $access_token
+ * @property string $access_token_expiration
+ * @property string $refresh_token
+ * @property string $role
+ */
+trait HasNorthstarToken
+{
+    /**
+     * Make sure that token information is never included in
+     * array or JSON responses by mistake.
+     *
+     * @return array
+     */
+    public function getHidden()
+    {
+        return array_merge($this->hidden, ['access_token', 'refresh_token', 'access_token_expiration']);
+    }
+
+    /**
+     * Get the Northstar ID for the user.
+     *
+     * @return string|null
+     */
+    public function getNorthstarIdentifier()
+    {
+        return $this->northstar_id;
+    }
+
+    /**
+     * Save the Northstar ID for the user.
+     *
+     * @return void
+     */
+    public function setNorthstarIdentifier($id)
+    {
+        $this->northstar_id = $id;
+    }
+
+    /**
+     * Get the access token for the user.
+     *
+     * @return AccessToken|null
+     */
+    public function getOAuthToken()
+    {
+        // If any of the required fields are empty, return null.
+        $hasAnEmptyField = empty($this->northstar_id) || empty($this->access_token) ||
+            empty($this->access_token_expiration) || empty($this->refresh_token) || empty($this->role);
+
+        if ($hasAnEmptyField) {
+            return null;
+        }
+
+        return new AccessToken([
+            'resource_owner_id' => $this->getNorthstarIdentifier(),
+            'access_token' => $this->access_token,
+            'refresh_token' => $this->refresh_token,
+            'expires' => $this->access_token_expiration,
+            'role' => $this->role,
+        ]);
+    }
+
+    /**
+     * Save the access token for the user.
+     *
+     * @param AccessToken $token
+     */
+    public function setOAuthToken(AccessToken $token)
+    {
+        $this->access_token = $token->getToken();
+        $this->access_token_expiration = $token->getExpires();
+        $this->refresh_token = $token->getRefreshToken();
+        $this->role = $token->getValues()['role'];
+    }
+
+    /**
+     * Clear the access token for the user.
+     *
+     * @return void
+     */
+    public function clearOAuthToken()
+    {
+        $this->access_token = null;
+        $this->access_token_expiration = null;
+        $this->refresh_token = null;
+    }
+}


### PR DESCRIPTION
#### Changes

This PR includes some refactoring that I ended up doing while tackling #30, with the goal of making it less likely we make mistakes when adding this library to client apps.

🛂 Adds a `NorthstarUserContract` and Laravel-specific implementation (as a trait that can be applied to the user Eloquent model), which is used to store/retrieve data throughout the client.

🙊 The token details are now hidden automatically by the `HasNorthstarToken` trait, so we don't have to remember to add those fields to the `$hidden` property on each application's user model.

🎫 Adds a `withToken()` method which lets you manually supply a token for the request (e.g. if you're making a call to another internal API with the token in the request's authorization header).

Closes DoSomething/TeamRocket#10.
#### How should this be reviewed?

I'd recommend going commit-by-commit rather than looking at the whole diff.

---

For review: @weerd
