### PR TITLE
Extracts Laravel introspection helpers into a little class.

### DIFF
--- a/src/Common/Introspector.php
+++ b/src/Common/Introspector.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DoSomething\Gateway\Common;
+
+class Introspector
+{
+    /**
+     * Returns all traits used by a class, its subclasses and trait of their traits.
+     * @see illuminate/support's `class_uses_recursive`
+     *
+     * @param  object|string  $class
+     * @return array
+     */
+    public static function getAllClassTraits($class)
+    {
+        $results = [];
+
+        foreach (array_merge([$class => $class], class_parents($class)) as $class) {
+            $results += self::getAllTraits($class);
+        }
+
+        return array_unique($results);
+    }
+
+    /**
+     * Get the base name of a namespaced class string/object.
+     * @see illuminate/support's `class_basename`
+     *
+     * @param $class
+     * @return string
+     */
+    public static function baseName($class)
+    {
+        $class = is_object($class) ? get_class($class) : $class;
+
+        return basename(str_replace('\\', '/', $class));
+    }
+
+    /**
+     * Returns all traits used by a trait and its traits.
+     * @see illuminate/support's `trait_uses_recursive`
+     *
+     * @param  string  $trait
+     * @return array
+     */
+    public static function getAllTraits($trait)
+    {
+        $traits = class_uses($trait);
+
+        foreach ($traits as $trait) {
+            $traits += trait_uses_recursive($trait);
+        }
+
+        return $traits;
+    }
+}

--- a/src/Common/Introspector.php
+++ b/src/Common/Introspector.php
@@ -48,7 +48,7 @@ class Introspector
         $traits = class_uses($trait);
 
         foreach ($traits as $trait) {
-            $traits += trait_uses_recursive($trait);
+            $traits += self::getAllTraits($trait);
         }
 
         return $traits;

--- a/src/Common/RestApiClient.php
+++ b/src/Common/RestApiClient.php
@@ -254,7 +254,7 @@ class RestApiClient
     {
         // Find what traits this class is using.
         $class = get_called_class();
-        $traits = array_keys(class_uses($class));
+        $traits = Introspector::getAllClassTraits($class);
 
         if (empty($options['headers'])) {
             $options['headers'] = [];
@@ -262,7 +262,7 @@ class RestApiClient
 
         // If these traits have a "hook" (uh oh!), run that before making a request.
         foreach ($traits as $trait) {
-            $function = 'run'.class_basename($trait).'Tasks';
+            $function = 'run'.Introspector::baseName($trait).'Tasks';
             if (method_exists($class, $method)) {
                 $this->{$function}($method, $path, $options, $withAuthorization);
             }


### PR DESCRIPTION
#### Changes

This pull request extracts some Laravel class introspection helpers we were relying on into a helper class. It fixes two issues: `class_basename` not being defined outside of Laravel apps, and that PHP's built-in `class_uses` [doesn't find inherited traits](https://github.com/DoSomething/gateway/pull/34#discussion_r82202401).

---

For review: @weerd @chloealee 
