### PR TITLE
Add tests for AuthorizesWithNorthstar trait & Northstar client.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",
-    "illuminate/database": "^5.2"
+    "illuminate/database": "^5.2",
+    "symfony/var-dumper": "^3.1"
   },
   "license": "MIT",
   "authors": [

--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -122,7 +122,7 @@ trait AuthorizesWithNorthstar
      * @param ServerRequestInterface $request
      * @param ResponseInterface $response
      * @param string $destination - The destination to redirect to on a successful login.
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|ResponseInterface
+     * @return ResponseInterface
      * @throws InternalException
      */
     public function authorize(ServerRequestInterface $request, ResponseInterface $response, $destination = '/')
@@ -395,6 +395,11 @@ trait AuthorizesWithNorthstar
 
             if (! empty($config['redirect_uri'])) {
                 $options['redirectUri'] = $this->getFrameworkBridge()->prepareUrl($config['redirect_uri']);
+            }
+
+            // Allow setting a custom handler (for mocking requests in tests).
+            if (! empty($this->config['handler'])) {
+                $options['handler'] = $this->config['handler'];
             }
 
             $this->authorizationServer = new NorthstarOAuthProvider($options);

--- a/src/Northstar.php
+++ b/src/Northstar.php
@@ -15,8 +15,9 @@ class Northstar extends RestApiClient
     /**
      * Create a new Northstar API client.
      * @param array $config
+     * @param array $overrides
      */
-    public function __construct($config = [])
+    public function __construct($config = [], $overrides = [])
     {
         $base_url = $config['url'];
 
@@ -29,7 +30,7 @@ class Northstar extends RestApiClient
             $this->bridge = $config['bridge'];
         }
 
-        parent::__construct($base_url);
+        parent::__construct($base_url, $overrides);
     }
 
     /**

--- a/src/NorthstarOAuthProvider.php
+++ b/src/NorthstarOAuthProvider.php
@@ -157,4 +157,19 @@ class NorthstarOAuthProvider extends AbstractProvider
     {
         return new NorthstarUser($response['data']);
     }
+
+    /**
+     * Return the list of options that can be passed to the HttpClient
+     *
+     * @param array $options An array of options to set on this provider.
+     *     Options include `clientId`, `clientSecret`, `redirectUri`, and `state`.
+     *     Individual providers may introduce more options, as needed.
+     * @return array The options to pass to the HttpClient constructor
+     */
+    protected function getAllowedClientOptions(array $options)
+    {
+        $options = parent::getAllowedClientOptions($options);
+
+        return array_merge($options, ['handler']);
+    }
 }

--- a/tests/Mocks/MockNorthstar.php
+++ b/tests/Mocks/MockNorthstar.php
@@ -1,0 +1,24 @@
+<?php
+
+use DoSomething\Gateway\Northstar;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+
+class MockNorthstar extends Northstar
+{
+    /**
+     * MockClient constructor.
+     *
+     * @param array $config
+     * @param array $responses - PSR responses to be returned, in order.
+     */
+    public function __construct($config, $responses)
+    {
+        $mock = new MockHandler($responses);
+        $handler = HandlerStack::create($mock);
+
+        $config = array_merge($config, ['handler' => $handler]);
+
+        parent::__construct($config, ['handler' => $handler]);
+    }
+}

--- a/tests/Mocks/MockOAuthBridge.php
+++ b/tests/Mocks/MockOAuthBridge.php
@@ -1,0 +1,147 @@
+<?php
+
+use DoSomething\Gateway\Contracts\NorthstarUserContract;
+use DoSomething\Gateway\Contracts\OAuthBridgeContract;
+use League\OAuth2\Client\Token\AccessToken;
+
+class MockOAuthBridge implements OAuthBridgeContract
+{
+    /**
+     * In-memory store for the access token.
+     *
+     * @var AccessToken
+     */
+    private $token = null;
+
+    /**
+     * Get the ID of the logged-in user.
+     *
+     * @return NorthstarUserContract|null
+     */
+    public function getCurrentUser()
+    {
+        // TODO: Implement getCurrentUser() method.
+    }
+
+    /**
+     * Get a user by their Northstar ID.
+     *
+     * @return NorthstarUserContract|null
+     */
+    public function getUser($id)
+    {
+        // TODO: Implement getUser() method.
+    }
+
+    /**
+     * Find or create a local user with the given Northstar ID.
+     *
+     * @param $id
+     * @return NorthstarUserContract
+     */
+    public function getOrCreateUser($id)
+    {
+        // TODO: Implement getOrCreateUser() method.
+    }
+
+    /**
+     * Get the OAuth client's token.
+     *
+     * @return \League\OAuth2\Client\Token\AccessToken|null
+     */
+    public function getClientToken()
+    {
+        return $this->token;
+    }
+
+    /**
+     * Save the access & refresh tokens for an authorized user.
+     *
+     * @param \League\OAuth2\Client\Token\AccessToken $token
+     * @internal param $userId - Northstar user ID
+     */
+    public function persistUserToken(AccessToken $token)
+    {
+        $this->token = $token;
+    }
+
+    /**
+     * Save the access token for an authorized client.
+     *
+     * @param $clientId - OAuth client ID
+     * @param $accessToken - Encoded OAuth access token
+     * @param $expiration - Access token expiration as UNIX timestamp
+     * @param $role - The role from the JWT
+     * @return void
+     */
+    public function persistClientToken($clientId, $accessToken, $expiration, $role)
+    {
+        // TODO: Implement persistClientToken() method.
+    }
+
+    /**
+     * If a refresh token is invalid, request the user's credentials
+     * by redirecting to the login screen.
+     *
+     * @return void
+     */
+    public function requestUserCredentials()
+    {
+        // TODO: Implement requestUserCredentials() method.
+    }
+
+    /**
+     * Save the OAuth state token to the session.
+     *
+     * @param $state
+     * @return void
+     */
+    public function saveStateToken($state)
+    {
+        // TODO: Implement saveStateToken() method.
+    }
+
+    /**
+     * Get a stored OAuth state token from the session.
+     *
+     * @return string
+     */
+    public function getStateToken()
+    {
+        // TODO: Implement getStateToken() method.
+    }
+
+    /**
+     * Create a session for the given user & access token.
+     *
+     * @param NorthstarUserContract $user
+     * @param AccessToken $token
+     * @return mixed
+     */
+    public function login(NorthstarUserContract $user, AccessToken $token)
+    {
+        // TODO: Implement login() method.
+    }
+
+    /**
+     * Destroy the current user session.
+     *
+     * @return mixed
+     */
+    public function logout()
+    {
+        // TODO: Implement logout() method.
+    }
+
+    /**
+     * Convert the given relative path to an absolute URL
+     * with the framework's URL generator.
+     *
+     * @param $url
+     * @return string
+     */
+    public function prepareUrl($url)
+    {
+        // TODO: Implement prepareUrl() method.
+    }
+}

--- a/tests/NorthstarTest.php
+++ b/tests/NorthstarTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use GuzzleHttp\Psr7\Response;
+
 class AuthorizesWithNorthstarTest extends TestCase
 {
     protected $defaultConfig = [
@@ -21,6 +23,35 @@ class AuthorizesWithNorthstarTest extends TestCase
      */
     public function testNorthstarApiClient()
     {
-        $this->markTestIncomplete();
+        $restClient = new MockNorthstar($this->defaultConfig, [/* ... */]);
+
+        $this->assertEquals((string) $restClient->getBaseUri(), 'https://northstar-phpunit.dosomething.org');
+    }
+
+    /**
+     * Test that we can request an access token and use it to retrieve
+     * a page using client credentials grant.
+     */
+    public function testGetAuthorizedPage()
+    {
+        $restClient = new MockNorthstar($this->defaultConfig, [
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'token_type' => 'Bearer',
+                'access_token' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6ImUwNmJjMDhlZGE5NjRiZmQwNjYzZjc5MzgxNDhkZ
+                TYzYjYzNzkxYmMxOTFhNTEwYmY4MDZlYzJhMGZiNjUzYzc1MjFhOWIzYTFmM2NjNjcyIn0.eyJpc3MiOiJodHRwOlwvXC9ub3J0aHN0Y
+                XIuZGV2OjgwMDAiLCJhdWQiOiJ0cnVzdGVkLXRlc3QtY2xpZW50IiwianRpIjoiZTA2YmMwOGVkYTk2NGJmZDA2NjNmNzkzODE0OGRlN
+                jNiNjM3OTFiYzE5MWE1MTBiZjgwNmVjMmEwZmI2NTNjNzUyMWE5YjNhMWYzY2M2NzIiLCJpYXQiOjE0NzYyMDEzMzEsIm5iZiI6MTQ3N
+                jIwMTMzMSwiZXhwIjoxNDc2MjA0OTMxLCJzdWIiOiIiLCJyb2xlIjoiIiwic2NvcGVzIjpbXX0.aFyfvihTvumdWPgtfXxKQZYKVGJw-
+                DnvUZO-XXNUgKYy8ngq0OTHMV00_VEqJVHPZVZ1FQv7sq-LcxpSpEM-VgfPsNUVuhJ8E3nX63ntTQQiv_CFBvippb1LJqVhfE7gzaKQc
+                eatw5dT25nDlzRQIrUY1kz1exGHUozvkHAeJ_g',
+                'expires_in' => 3600,
+            ])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'status' => 'good',
+            ])),
+        ]);
+
+        $response = $restClient->get('status');
+        $this->assertEquals($response, ['status' => 'good']);
     }
 }

--- a/tests/NorthstarTest.php
+++ b/tests/NorthstarTest.php
@@ -1,0 +1,26 @@
+<?php
+
+class AuthorizesWithNorthstarTest extends TestCase
+{
+    protected $defaultConfig = [
+        'grant' => 'client_credentials',
+        'url' => 'https://northstar-phpunit.dosomething.org', // not a real server!
+        'bridge' => MockOAuthBridge::class,
+
+        // Then, configure client ID, client secret, and scopes per grant.
+        'client_credentials' => [
+            'client_id' => 'example',
+            'client_secret' => 'secret1',
+            'scope' => ['user'],
+        ],
+    ];
+
+    /**
+     * Test that we can instantiate a client that authorizes with Northstar.
+     * @skip
+     */
+    public function testNorthstarApiClient()
+    {
+        $this->markTestIncomplete();
+    }
+}


### PR DESCRIPTION
#### Changes

This PR adds some very simple tests for the `AuthorizesWithNorthstar` trait and `Northstar` client. This involves creating a mock OAuth bridge and updating the client/provider so we can pass in a mock HTTP handler.
#### How should this be reviewed?

Tests should pass!

I think we can probably simplify things more in the future (like how we have to pass handler to our Guzzle client and the OAuth package's separate one), but hoping to build up test coverage with as few modifications as possible before doing too much heavy refactoring. Safety first! 😄 

---

For review: @weerd
