### PR TITLE
Rename classes to use consistent capitalization for acronyms.

### DIFF
--- a/src/Common/ApiCollection.php
+++ b/src/Common/ApiCollection.php
@@ -7,7 +7,7 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 
-abstract class APICollection implements ArrayAccess, Countable, IteratorAggregate
+abstract class ApiCollection implements ArrayAccess, Countable, IteratorAggregate
 {
     /**
      * The items returned from the request.
@@ -90,7 +90,7 @@ abstract class APICollection implements ArrayAccess, Countable, IteratorAggregat
     /**
      * Get the first item from the collection.
      *
-     * @return APIResponse|null
+     * @return ApiResponse|null
      */
     public function first()
     {

--- a/src/Common/ApiResponse.php
+++ b/src/Common/ApiResponse.php
@@ -4,7 +4,7 @@ namespace DoSomething\Gateway\Common;
 
 use Carbon\Carbon;
 
-abstract class APIResponse
+class ApiResponse
 {
     /**
      * Raw API response data.

--- a/src/Resources/NorthstarClient.php
+++ b/src/Resources/NorthstarClient.php
@@ -2,9 +2,9 @@
 
 namespace DoSomething\Gateway\Resources;
 
-use DoSomething\Gateway\Common\APIResponse;
+use DoSomething\Gateway\Common\ApiResponse;
 
-class NorthstarClient extends APIResponse
+class NorthstarClient extends ApiResponse
 {
     // OAuth 2 client
 }

--- a/src/Resources/NorthstarClientCollection.php
+++ b/src/Resources/NorthstarClientCollection.php
@@ -2,9 +2,9 @@
 
 namespace DoSomething\Gateway\Resources;
 
-use DoSomething\Gateway\Common\APICollection;
+use DoSomething\Gateway\Common\ApiCollection;
 
-class NorthstarClientCollection extends APICollection
+class NorthstarClientCollection extends ApiCollection
 {
     public function __construct($response)
     {

--- a/src/Resources/NorthstarUser.php
+++ b/src/Resources/NorthstarUser.php
@@ -2,12 +2,12 @@
 
 namespace DoSomething\Gateway\Resources;
 
-use DoSomething\Gateway\Common\APIResponse;
+use DoSomething\Gateway\Common\ApiResponse;
 use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberUtil;
 
-class NorthstarUser extends APIResponse implements ResourceOwnerInterface
+class NorthstarUser extends ApiResponse implements ResourceOwnerInterface
 {
     /**
      * Create a new User from the given API response.

--- a/src/Resources/NorthstarUserCollection.php
+++ b/src/Resources/NorthstarUserCollection.php
@@ -2,9 +2,9 @@
 
 namespace DoSomething\Gateway\Resources;
 
-use DoSomething\Gateway\Common\APICollection;
+use DoSomething\Gateway\Common\ApiCollection;
 
-class NorthstarUserCollection extends APICollection
+class NorthstarUserCollection extends ApiCollection
 {
     public function __construct($response)
     {


### PR DESCRIPTION
#### Changes

We use `StudlyCase` for class names for consistency with other Laravel/PSR-2 code (for example, `RestApiClient` uses the correct capitalization). This PR just updates `ApiResponse` and `ApiCollection` to match the same style.

---

For review: @weerd 
