### PR TITLE
Add a test for the user index.

### DIFF
--- a/tests/Helpers/JsonResponse.php
+++ b/tests/Helpers/JsonResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+use GuzzleHttp\Psr7\Response;
+
+class JsonResponse extends Response
+{
+    /**
+     * Make a new mock JsonResponse.
+     *
+     * @param array $body - The contents of the response.
+     * @param int $code - The HTTP status code.
+     */
+    public function __construct(array $body, $code = 200)
+    {
+        parent::__construct($code, ['Content-Type' => 'application/json'], json_encode($body));
+    }
+}

--- a/tests/Helpers/JwtResponse.php
+++ b/tests/Helpers/JwtResponse.php
@@ -1,0 +1,24 @@
+<?php
+
+class JwtResponse extends JsonResponse
+{
+    /**
+     * Make a new mock JWT token response.
+     */
+    public function __construct()
+    {
+        $body = [
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+            'access_token' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6ImUwNmJjMDhlZGE5NjRiZmQwNjYzZjc5MzgxNDhkZ
+                TYzYjYzNzkxYmMxOTFhNTEwYmY4MDZlYzJhMGZiNjUzYzc1MjFhOWIzYTFmM2NjNjcyIn0.eyJpc3MiOiJodHRwOlwvXC9ub3J0aHN0Y
+                XIuZGV2OjgwMDAiLCJhdWQiOiJ0cnVzdGVkLXRlc3QtY2xpZW50IiwianRpIjoiZTA2YmMwOGVkYTk2NGJmZDA2NjNmNzkzODE0OGRlN
+                jNiNjM3OTFiYzE5MWE1MTBiZjgwNmVjMmEwZmI2NTNjNzUyMWE5YjNhMWYzY2M2NzIiLCJpYXQiOjE0NzYyMDEzMzEsIm5iZiI6MTQ3N
+                jIwMTMzMSwiZXhwIjoxNDc2MjA0OTMxLCJzdWIiOiIiLCJyb2xlIjoiIiwic2NvcGVzIjpbXX0.aFyfvihTvumdWPgtfXxKQZYKVGJw-
+                DnvUZO-XXNUgKYy8ngq0OTHMV00_VEqJVHPZVZ1FQv7sq-LcxpSpEM-VgfPsNUVuhJ8E3nX63ntTQQiv_CFBvippb1LJqVhfE7gzaKQc
+                eatw5dT25nDlzRQIrUY1kz1exGHUozvkHAeJ_g',
+        ];
+
+        parent::__construct($body, 200);
+    }
+}

--- a/tests/NorthstarTest.php
+++ b/tests/NorthstarTest.php
@@ -54,4 +54,60 @@ class AuthorizesWithNorthstarTest extends TestCase
         $response = $restClient->get('status');
         $this->assertEquals($response, ['status' => 'good']);
     }
+
+    /**
+     * Test that we can use the "all users" endpoint.
+     */
+    public function testGetAllUsers()
+    {
+        $restClient = new MockNorthstar($this->defaultConfig, [
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'token_type' => 'Bearer',
+                'access_token' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6ImUwNmJjMDhlZGE5NjRiZmQwNjYzZjc5MzgxNDhkZ
+                TYzYjYzNzkxYmMxOTFhNTEwYmY4MDZlYzJhMGZiNjUzYzc1MjFhOWIzYTFmM2NjNjcyIn0.eyJpc3MiOiJodHRwOlwvXC9ub3J0aHN0Y
+                XIuZGV2OjgwMDAiLCJhdWQiOiJ0cnVzdGVkLXRlc3QtY2xpZW50IiwianRpIjoiZTA2YmMwOGVkYTk2NGJmZDA2NjNmNzkzODE0OGRlN
+                jNiNjM3OTFiYzE5MWE1MTBiZjgwNmVjMmEwZmI2NTNjNzUyMWE5YjNhMWYzY2M2NzIiLCJpYXQiOjE0NzYyMDEzMzEsIm5iZiI6MTQ3N
+                jIwMTMzMSwiZXhwIjoxNDc2MjA0OTMxLCJzdWIiOiIiLCJyb2xlIjoiIiwic2NvcGVzIjpbXX0.aFyfvihTvumdWPgtfXxKQZYKVGJw-
+                DnvUZO-XXNUgKYy8ngq0OTHMV00_VEqJVHPZVZ1FQv7sq-LcxpSpEM-VgfPsNUVuhJ8E3nX63ntTQQiv_CFBvippb1LJqVhfE7gzaKQc
+                eatw5dT25nDlzRQIrUY1kz1exGHUozvkHAeJ_g',
+                'expires_in' => 3600,
+            ])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'data' => [
+                    [
+                        'id' => '5480c950bffebc651c8b456f',
+                        'first_name' => 'John',
+                        'last_name' => 'Doe',
+                    ],
+                    [
+                        'id' => '5480c950ce5fbc2145eb7721',
+                        'first_name' => 'Jane',
+                        'last_name' => 'Smith',
+                    ],
+                ],
+                'meta' => [
+                    'pagination' => [
+                        'total' => 65,
+                        'count' => 20,
+                        'per_page' => 15,
+                        'current_page' => 1,
+                        'total_pages' => 5,
+                        'links' => [
+                            'next' => 'https://northstar.dosomething.org/v1/users?page=2',
+                        ],
+                    ],
+                ],
+            ])),
+        ]);
+
+        $response = $restClient->getAllUsers();
+
+        // It should successfully serialize into a collection.
+        $this->assertInstanceOf(\DoSomething\Gateway\Common\ApiCollection::class, $response);
+
+        // And we should be able to traverse and read values from that.
+        $this->assertEquals('John', $response[0]->first_name);
+        $this->assertEquals('Jane', $response[1]->first_name);
+        $this->assertEquals(2, $response->count());
+    }
 }

--- a/tests/NorthstarTest.php
+++ b/tests/NorthstarTest.php
@@ -1,8 +1,6 @@
 <?php
 
-use GuzzleHttp\Psr7\Response;
-
-class AuthorizesWithNorthstarTest extends TestCase
+class NorthstarTest extends TestCase
 {
     protected $defaultConfig = [
         'grant' => 'client_credentials',
@@ -35,20 +33,10 @@ class AuthorizesWithNorthstarTest extends TestCase
     public function testGetAuthorizedPage()
     {
         $restClient = new MockNorthstar($this->defaultConfig, [
-            new Response(200, ['Content-Type' => 'application/json'], json_encode([
-                'token_type' => 'Bearer',
-                'access_token' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6ImUwNmJjMDhlZGE5NjRiZmQwNjYzZjc5MzgxNDhkZ
-                TYzYjYzNzkxYmMxOTFhNTEwYmY4MDZlYzJhMGZiNjUzYzc1MjFhOWIzYTFmM2NjNjcyIn0.eyJpc3MiOiJodHRwOlwvXC9ub3J0aHN0Y
-                XIuZGV2OjgwMDAiLCJhdWQiOiJ0cnVzdGVkLXRlc3QtY2xpZW50IiwianRpIjoiZTA2YmMwOGVkYTk2NGJmZDA2NjNmNzkzODE0OGRlN
-                jNiNjM3OTFiYzE5MWE1MTBiZjgwNmVjMmEwZmI2NTNjNzUyMWE5YjNhMWYzY2M2NzIiLCJpYXQiOjE0NzYyMDEzMzEsIm5iZiI6MTQ3N
-                jIwMTMzMSwiZXhwIjoxNDc2MjA0OTMxLCJzdWIiOiIiLCJyb2xlIjoiIiwic2NvcGVzIjpbXX0.aFyfvihTvumdWPgtfXxKQZYKVGJw-
-                DnvUZO-XXNUgKYy8ngq0OTHMV00_VEqJVHPZVZ1FQv7sq-LcxpSpEM-VgfPsNUVuhJ8E3nX63ntTQQiv_CFBvippb1LJqVhfE7gzaKQc
-                eatw5dT25nDlzRQIrUY1kz1exGHUozvkHAeJ_g',
-                'expires_in' => 3600,
-            ])),
-            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+            new JwtResponse(),
+            new JsonResponse([
                 'status' => 'good',
-            ])),
+            ]),
         ]);
 
         $response = $restClient->get('status');
@@ -61,18 +49,8 @@ class AuthorizesWithNorthstarTest extends TestCase
     public function testGetAllUsers()
     {
         $restClient = new MockNorthstar($this->defaultConfig, [
-            new Response(200, ['Content-Type' => 'application/json'], json_encode([
-                'token_type' => 'Bearer',
-                'access_token' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImp0aSI6ImUwNmJjMDhlZGE5NjRiZmQwNjYzZjc5MzgxNDhkZ
-                TYzYjYzNzkxYmMxOTFhNTEwYmY4MDZlYzJhMGZiNjUzYzc1MjFhOWIzYTFmM2NjNjcyIn0.eyJpc3MiOiJodHRwOlwvXC9ub3J0aHN0Y
-                XIuZGV2OjgwMDAiLCJhdWQiOiJ0cnVzdGVkLXRlc3QtY2xpZW50IiwianRpIjoiZTA2YmMwOGVkYTk2NGJmZDA2NjNmNzkzODE0OGRlN
-                jNiNjM3OTFiYzE5MWE1MTBiZjgwNmVjMmEwZmI2NTNjNzUyMWE5YjNhMWYzY2M2NzIiLCJpYXQiOjE0NzYyMDEzMzEsIm5iZiI6MTQ3N
-                jIwMTMzMSwiZXhwIjoxNDc2MjA0OTMxLCJzdWIiOiIiLCJyb2xlIjoiIiwic2NvcGVzIjpbXX0.aFyfvihTvumdWPgtfXxKQZYKVGJw-
-                DnvUZO-XXNUgKYy8ngq0OTHMV00_VEqJVHPZVZ1FQv7sq-LcxpSpEM-VgfPsNUVuhJ8E3nX63ntTQQiv_CFBvippb1LJqVhfE7gzaKQc
-                eatw5dT25nDlzRQIrUY1kz1exGHUozvkHAeJ_g',
-                'expires_in' => 3600,
-            ])),
-            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+            new JwtResponse(),
+            new JsonResponse([
                 'data' => [
                     [
                         'id' => '5480c950bffebc651c8b456f',
@@ -87,17 +65,15 @@ class AuthorizesWithNorthstarTest extends TestCase
                 ],
                 'meta' => [
                     'pagination' => [
-                        'total' => 65,
-                        'count' => 20,
+                        'total' => 2,
+                        'count' => 2,
                         'per_page' => 15,
                         'current_page' => 1,
-                        'total_pages' => 5,
-                        'links' => [
-                            'next' => 'https://northstar.dosomething.org/v1/users?page=2',
-                        ],
+                        'total_pages' => 1,
+                        'links' => [],
                     ],
                 ],
-            ])),
+            ]),
         ]);
 
         $response = $restClient->getAllUsers();

--- a/tests/RestApiClientTest.php
+++ b/tests/RestApiClientTest.php
@@ -23,7 +23,7 @@ class RestApiClientTest extends TestCase
     public function testMakeGetRequest()
     {
         $client = new MockClient('https://api.xavierinstitute.edu', [
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['teacher' => 'Charles Xavier'])),
+            new JsonResponse(['teacher' => 'Charles Xavier']),
         ]);
 
         $this->assertEquals($client->get('classes/1'), ['teacher' => 'Charles Xavier']);
@@ -47,7 +47,7 @@ class RestApiClientTest extends TestCase
     public function testMakePostRequest()
     {
         $client = new MockClient('https://api.xavierinstitute.edu', [
-            new Response(201, ['Content-Type' => 'application/json'], json_encode(['teacher' => 'Charles Xavier'])),
+            new JsonResponse(['teacher' => 'Charles Xavier'], 201),
         ]);
 
         $this->assertEquals($client->post('teachers'), ['teacher' => 'Charles Xavier']);
@@ -59,7 +59,7 @@ class RestApiClientTest extends TestCase
     public function testHandlesValidationError()
     {
         $client = new MockClient('https://api.xavierinstitute.edu', [
-            new Response(422, ['Content-Type' => 'application/json'], json_encode([
+            new JsonResponse([
                 'error' => [
                     'code' => 422,
                     'message' => '',
@@ -67,7 +67,7 @@ class RestApiClientTest extends TestCase
                         'teacher' => ['The provided teacher is not employed here.'],
                     ],
                 ],
-            ])),
+            ], 422),
         ]);
 
         $this->setExpectedException(ValidationException::class);
@@ -81,7 +81,7 @@ class RestApiClientTest extends TestCase
     {
         $body = ['teacher' => 'Charles Xavier', 'job' => 'Professor'];
         $client = new MockClient('https://api.xavierinstitute.edu', [
-            new Response(200, ['Content-Type' => 'application/json'], json_encode($body)),
+            new JsonResponse($body),
         ]);
 
         $this->assertEquals($client->put('teachers/1', ['job' => 'Professor']), $body);
@@ -93,12 +93,12 @@ class RestApiClientTest extends TestCase
     public function testMakeDeleteRequest()
     {
         $client = new MockClient('https://api.xavierinstitute.edu', [
-            new Response(201, ['Content-Type' => 'application/json'], json_encode([
+            new JsonResponse([
                 'success' => [
                     'code' => 200,
                     'message' => 'Deleted.',
                 ],
-            ])),
+            ], 200),
         ]);
 
         $this->assertEquals($client->delete('teachers/1'), true);


### PR DESCRIPTION
#### Changes

This pull request adds a functional test for the `getAllUsers` function in the Northstar API client, which gets us some super high-level functional testing on a lot of the pieces that go into that: OAuth token requests/entities/storage, API response model and collection classes.

It also adds some little helper classes to help make mocked responses a bit more easily.

---

For review: @weerd 
