### PR TITLE
Adding PSR4 namespace for tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
     "files": ["src/Laravel/helpers.php"]
   },
   "autoload-dev": {
-    "classmap": ["tests/TestCase.php"]
+    "classmap": ["tests/TestCase.php"],
+    "psr-4": {
+      "DoSomething\\GatewayTests\\": "tests/"
+    }
   }
 }

--- a/tests/Helpers/JsonResponse.php
+++ b/tests/Helpers/JsonResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace DoSomething\GatewayTests\Helpers;
+
 use GuzzleHttp\Psr7\Response;
 
 class JsonResponse extends Response

--- a/tests/Helpers/JwtResponse.php
+++ b/tests/Helpers/JwtResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace DoSomething\GatewayTests\Helpers;
+
 class JwtResponse extends JsonResponse
 {
     /**

--- a/tests/Helpers/UserResponse.php
+++ b/tests/Helpers/UserResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace DoSomething\GatewayTests\Helpers;
+
+class UserResponse extends JsonResponse
+{
+    /**
+     * Make a new mock user response.
+     */
+    public function __construct($code = 200)
+    {
+        $body = [
+            'data' => [
+                'id' => '5480c950ce5fbc2145eb7721',
+                'email' => 'kitty@xavierinstitute.edu',
+                'mobile' => '5551234567',
+                'facebook_id' => '10101010101010101',
+                'drupal_id' => '123456',
+                'addr_street1' => '1407 Graymalkin Lane',
+                'addr_street2' => '',
+                'addr_city' => 'Salem Center',
+                'addr_state' => 'New York',
+                'addr_zip' => '10560',
+                'country' => 'US',
+                'birthdate' => '01/09/80',
+                'first_name' => 'Katherine',
+                'last_name' => 'Pryde',
+                'role' => 'user',
+                'updated_at' => '2016-10-14T19:33:24+0000',
+                'created_at' => '2016-10-14T19:33:24+0000',
+            ],
+        ];
+
+        parent::__construct($body, $code);
+    }
+}

--- a/tests/Helpers/UsersResponse.php
+++ b/tests/Helpers/UsersResponse.php
@@ -48,7 +48,7 @@ class UsersResponse extends JsonResponse
                     'role' => 'user',
                     'updated_at' => '2016-10-17T19:33:24+0000',
                     'created_at' => '2016-10-17T19:33:24+0000',
-                ]
+                ],
             ],
             'meta' => [
                 'pagination' => [
@@ -57,7 +57,7 @@ class UsersResponse extends JsonResponse
                     'per_page' => 15,
                     'current_page' => 1,
                     'total_pages' => 1,
-                    'links' => []
+                    'links' => [],
                 ],
             ],
         ];

--- a/tests/Helpers/UsersResponse.php
+++ b/tests/Helpers/UsersResponse.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace DoSomething\GatewayTests\Helpers;
+
+class UsersResponse extends JsonResponse
+{
+    /**
+     * Make a new mock users response.
+     */
+    public function __construct($code = 200)
+    {
+        $body = [
+            'data' => [
+                [
+                    'id' => '5480c950ce5fbc2145eb7721',
+                    'email' => 'kitty@xavierinstitute.edu',
+                    'mobile' => '5551234567',
+                    'facebook_id' => '10101010101010101',
+                    'drupal_id' => '123456',
+                    'addr_street1' => '1407 Graymalkin Lane',
+                    'addr_street2' => '',
+                    'addr_city' => 'Salem Center',
+                    'addr_state' => 'New York',
+                    'addr_zip' => '10560',
+                    'country' => 'US',
+                    'birthdate' => '01/09/80',
+                    'first_name' => 'Katherine',
+                    'last_name' => 'Pryde',
+                    'role' => 'user',
+                    'updated_at' => '2016-10-14T19:33:24+0000',
+                    'created_at' => '2016-10-14T19:33:24+0000',
+                ],
+                [
+                    'id' => '5480c950bffebc651c8b456f',
+                    'email' => 'bobby@xavierinstitute.edu',
+                    'mobile' => '5557654321',
+                    'facebook_id' => '20202020202020202',
+                    'drupal_id' => '654321',
+                    'addr_street1' => '1407 Graymalkin Lane',
+                    'addr_street2' => '',
+                    'addr_city' => 'Salem Center',
+                    'addr_state' => 'New York',
+                    'addr_zip' => '10560',
+                    'country' => 'US',
+                    'birthdate' => '09/10/63',
+                    'first_name' => 'Robert',
+                    'last_name' => 'Drake',
+                    'role' => 'user',
+                    'updated_at' => '2016-10-17T19:33:24+0000',
+                    'created_at' => '2016-10-17T19:33:24+0000',
+                ]
+            ],
+            'meta' => [
+                'pagination' => [
+                    'total' => 2,
+                    'count' => 2,
+                    'per_page' => 15,
+                    'current_page' => 1,
+                    'total_pages' => 1,
+                    'links' => []
+                ],
+            ],
+        ];
+
+        parent::__construct($body, $code);
+    }
+}

--- a/tests/NorthstarTest.php
+++ b/tests/NorthstarTest.php
@@ -1,5 +1,10 @@
 <?php
 
+use DoSomething\GatewayTests\Helpers\JsonResponse;
+use DoSomething\GatewayTests\Helpers\JwtResponse;
+use DoSomething\GatewayTests\Helpers\UserResponse;
+use DoSomething\GatewayTests\Helpers\UsersResponse;
+
 class NorthstarTest extends TestCase
 {
     protected $defaultConfig = [
@@ -50,30 +55,7 @@ class NorthstarTest extends TestCase
     {
         $restClient = new MockNorthstar($this->defaultConfig, [
             new JwtResponse,
-            new JsonResponse([
-                'data' => [
-                    [
-                        'id' => '5480c950bffebc651c8b456f',
-                        'first_name' => 'Bobby',
-                        'last_name' => 'Drake',
-                    ],
-                    [
-                        'id' => '5480c950ce5fbc2145eb7721',
-                        'first_name' => 'Katherine',
-                        'last_name' => 'Pryde',
-                    ],
-                ],
-                'meta' => [
-                    'pagination' => [
-                        'total' => 2,
-                        'count' => 2,
-                        'per_page' => 15,
-                        'current_page' => 1,
-                        'total_pages' => 1,
-                        'links' => [],
-                    ],
-                ],
-            ]),
+            new UsersResponse,
         ]);
 
         $response = $restClient->getAllUsers();
@@ -82,8 +64,8 @@ class NorthstarTest extends TestCase
         $this->assertInstanceOf(\DoSomething\Gateway\Common\ApiCollection::class, $response);
 
         // And we should be able to traverse and read values from that.
-        $this->assertEquals('Bobby', $response[0]->first_name);
-        $this->assertEquals('Katherine', $response[1]->first_name);
+        $this->assertEquals('Katherine', $response[0]->first_name);
+        $this->assertEquals('Robert', $response[1]->first_name);
         $this->assertEquals(2, $response->count());
     }
 
@@ -94,17 +76,7 @@ class NorthstarTest extends TestCase
     {
         $restClient = new MockNorthstar($this->defaultConfig, [
             new JwtResponse,
-            new JsonResponse([
-                'data' => [
-                    'id' => '5480c950ce5fbc2145eb7721',
-                    'email' => 'kitty@xavierinstitute.edu',
-                    'mobile' => '5555555555',
-                    'facebook_id' => '10101010101010101',
-                    'drupal_id' => '123456',
-                    'first_name' => 'Katherine',
-                    'last_name' => 'Pryde',
-                ],
-            ]),
+            new UserResponse,
         ]);
 
         $response = $restClient->getUser('id', '5480c950ce5fbc2145eb7721');
@@ -119,17 +91,7 @@ class NorthstarTest extends TestCase
     {
         $restClient = new MockNorthstar($this->defaultConfig, [
             new JwtResponse,
-            new JsonResponse([
-                'data' => [
-                    'id' => '5480c950ce5fbc2145eb7721',
-                    'email' => 'kitty@xavierinstitute.edu',
-                    'mobile' => '5551234567',
-                    'facebook_id' => '10101010101010101',
-                    'drupal_id' => '123456',
-                    'first_name' => 'Katherine',
-                    'last_name' => 'Pryde',
-                ],
-            ]),
+            new UserResponse,
         ]);
 
         $response = $restClient->getUser('mobile', '5551234567');
@@ -144,17 +106,7 @@ class NorthstarTest extends TestCase
     {
         $restClient = new MockNorthstar($this->defaultConfig, [
             new JwtResponse,
-            new JsonResponse([
-                'data' => [
-                    'id' => '5480c950ce5fbc2145eb7721',
-                    'email' => 'kitty@xavierinstitute.edu',
-                    'mobile' => '5551234567',
-                    'facebook_id' => '10101010101010101',
-                    'drupal_id' => '123456',
-                    'first_name' => 'Katherine',
-                    'last_name' => 'Pryde',
-                ],
-            ]),
+            new UserResponse,
         ]);
 
         $response = $restClient->getUser('email', 'kitty@xavierinstitute.edu');
@@ -169,17 +121,7 @@ class NorthstarTest extends TestCase
     {
         $restClient = new MockNorthstar($this->defaultConfig, [
             new JwtResponse,
-            new JsonResponse([
-                'data' => [
-                    'id' => '5480c950ce5fbc2145eb7721',
-                    'email' => 'kitty@xavierinstitute.edu',
-                    'mobile' => '5551234567',
-                    'facebook_id' => '10101010101010101',
-                    'drupal_id' => '123456',
-                    'first_name' => 'Katherine',
-                    'last_name' => 'Pryde',
-                ],
-            ]),
+            new UserResponse,
         ]);
 
         $response = $restClient->getUser('drupal_id', '123456');
@@ -194,17 +136,7 @@ class NorthstarTest extends TestCase
     {
         $restClient = new MockNorthstar($this->defaultConfig, [
             new JwtResponse,
-            new JsonResponse([
-                'data' => [
-                    'id' => '5480c950ce5fbc2145eb7721',
-                    'email' => 'kitty@xavierinstitute.edu',
-                    'mobile' => '5551234567',
-                    'facebook_id' => '10101010101010101',
-                    'drupal_id' => '123456',
-                    'first_name' => 'Katherine',
-                    'last_name' => 'Pryde',
-                ],
-            ]),
+            new UserResponse,
         ]);
 
         $response = $restClient->getUser('facebook_id', '10101010101010101');

--- a/tests/RestApiClientTest.php
+++ b/tests/RestApiClientTest.php
@@ -2,6 +2,7 @@
 
 use DoSomething\Gateway\Common\RestApiClient;
 use DoSomething\Gateway\Exceptions\ValidationException;
+use DoSomething\GatewayTests\Helpers\JsonResponse;
 use GuzzleHttp\Psr7\Response;
 
 class RestApiClientTest extends TestCase


### PR DESCRIPTION
This PR implements the use of PSR-4 namespacing for our tests, as well as adding helper classes for a custom `UserResponse` and `UsersResponse` so we don't need to keep duplicating user data for each test in the test code.

---

@DFurnes 
