### PR TITLE
Basic Gambit API integration

### DIFF
--- a/src/Gambit.php
+++ b/src/Gambit.php
@@ -4,6 +4,7 @@ namespace DoSomething\Gateway;
 
 use DoSomething\Gateway\Common\RestApiClient;
 use DoSomething\Gateway\Resources\GambitCampaign;
+use DoSomething\Gateway\Resources\GambitCampaignCollection;
 
 class Gambit extends RestApiClient
 {
@@ -28,24 +29,21 @@ class Gambit extends RestApiClient
     }
 
     /**
-     * Send a GET request to return all users matching a given
-     * query from Northstar.
+     * Send a GET request to return all campaigns.
      *
-     * @param array $inputs - Filter, search, or pagination queries
-     * @return NorthstarUserCollection
+     * @return GambitCampaignCollection
      */
-    // public function getAllUsers($inputs = [])
-    // {
-    //     $response = $this->get('v1/users', $inputs);
-
-    //     return new NorthstarUserCollection($response);
-    // }
+    public function getAllCampaigns()
+    {
+        $response = $this->get('v1/campaigns');
+        return new GambitCampaignCollection($response);
+    }
 
     /**
-     * Send a GET request to return a user with that id.
+     * Send a GET request to return a campaign with that id.
      *
      * @param string $id - ID
-     * @return NorthstarUser
+     * @return GambitCampaign
      */
     public function getCampaign($id)
     {

--- a/src/Gambit.php
+++ b/src/Gambit.php
@@ -8,7 +8,6 @@ use DoSomething\Gateway\Resources\GambitCampaignCollection;
 
 class Gambit extends RestApiClient
 {
-
     /**
      * Configuration array.
      *
@@ -36,6 +35,7 @@ class Gambit extends RestApiClient
     public function getAllCampaigns()
     {
         $response = $this->get('v1/campaigns');
+
         return new GambitCampaignCollection($response);
     }
 
@@ -55,5 +55,4 @@ class Gambit extends RestApiClient
 
         return new GambitCampaign($response['data']);
     }
-
 }

--- a/src/Gambit.php
+++ b/src/Gambit.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace DoSomething\Gateway;
+
+use DoSomething\Gateway\Common\RestApiClient;
+use DoSomething\Gateway\Resources\GambitCampaign;
+
+class Gambit extends RestApiClient
+{
+
+    /**
+     * Configuration array.
+     *
+     * @var string
+     */
+    protected $config;
+
+    /**
+     * Create a new Gambit API client.
+     * @param array $config
+     * @param array $overrides
+     */
+    public function __construct($config = [], $overrides = [])
+    {
+        // Save configuration.
+        $this->config = $config;
+        parent::__construct($config['url'], $overrides);
+    }
+
+    /**
+     * Send a GET request to return all users matching a given
+     * query from Northstar.
+     *
+     * @param array $inputs - Filter, search, or pagination queries
+     * @return NorthstarUserCollection
+     */
+    // public function getAllUsers($inputs = [])
+    // {
+    //     $response = $this->get('v1/users', $inputs);
+
+    //     return new NorthstarUserCollection($response);
+    // }
+
+    /**
+     * Send a GET request to return a user with that id.
+     *
+     * @param string $id - ID
+     * @return NorthstarUser
+     */
+    public function getCampaign($id)
+    {
+        $response = $this->get('v1/campaigns/' . $id);
+
+        if (is_null($response)) {
+            return null;
+        }
+
+        return new GambitCampaign($response['data']);
+    }
+
+}

--- a/src/Resources/GambitCampaign.php
+++ b/src/Resources/GambitCampaign.php
@@ -4,15 +4,12 @@ namespace DoSomething\Gateway\Resources;
 
 use DoSomething\Gateway\Common\ApiResponse;
 
-
 class GambitCampaign extends ApiResponse
 {
-
-  /**
-   * The attributes that should be mutated to dates.
-   *
-   * @var array
-   */
-  protected $dates = [];
-    
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array
+     */
+    protected $dates = [];
 }

--- a/src/Resources/GambitCampaign.php
+++ b/src/Resources/GambitCampaign.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DoSomething\Gateway\Resources;
+
+use DoSomething\Gateway\Common\ApiResponse;
+
+
+class GambitCampaign extends ApiResponse
+{
+
+  /**
+   * The attributes that should be mutated to dates.
+   *
+   * @var array
+   */
+  protected $dates = [];
+    
+}

--- a/src/Resources/GambitCampaignCollection.php
+++ b/src/Resources/GambitCampaignCollection.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DoSomething\Gateway\Resources;
+
+use DoSomething\Gateway\Common\ApiCollection;
+
+class GambitCampaignCollection extends ApiCollection
+{
+    public function __construct($response)
+    {
+        parent::__construct($response, GambitCampaign::class);
+    }
+}

--- a/tests/GambitTest.php
+++ b/tests/GambitTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use DoSomething\GatewayTests\Helpers\JsonResponse;
 use DoSomething\GatewayTests\Helpers\Gambit\CampaignResponse;
 use DoSomething\GatewayTests\Helpers\Gambit\CampaignsResponse;
 
@@ -89,5 +88,4 @@ class GambitTest extends PHPUnit_Framework_TestCase
         $this->assertContainsOnly('string', $campaign->mobilecommons_keywords);
         $this->assertEquals(['SWAPBOT'], $campaign->mobilecommons_keywords);
     }
-
 }

--- a/tests/GambitTest.php
+++ b/tests/GambitTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use DoSomething\GatewayTests\Helpers\JsonResponse;
+use DoSomething\GatewayTests\Helpers\Gambit\CampaignResponse;
+// use DoSomething\GatewayTests\Helpers\Gambit\CampaignsResponse;
+
+class GambitTest extends PHPUnit_Framework_TestCase
+{
+    protected $defaultConfig = [
+        'url' => 'https://gambit-phpunit.dosomething.org', // not a real server!
+    ];
+
+    /**
+     * Test that we can retrieve a campaign by their ID.
+     */
+    public function testGetCampaignById()
+    {
+        $restClient = new MockGambit($this->defaultConfig, [
+            new CampaignResponse,
+        ]);
+        $campaign = $restClient->getCampaign(4944);
+
+        // id
+        $this->assertEquals(4944, $campaign->id);
+
+        // rb_verb
+        $this->assertEquals('Swappin Stories', $campaign->rb_verb);
+
+        // rb_noun
+        $this->assertEquals('Seniors', $campaign->rb_noun);
+
+        // msg_rb_confirmation
+        $this->assertEquals(
+            'Wait, your Grandma did WHAT? Thanks for playing and swapping stories!',
+            $campaign->msg_rb_confirmation
+        );
+
+        // title
+        $this->assertEquals('Senior Story Swap', $campaign->title);
+
+        // tagline
+        $this->assertEquals(
+            'Swap stories with an older adult to decrease isolation.',
+            $campaign->tagline
+        );
+
+        // status
+        $this->assertEquals('closed', $campaign->status);
+
+        // msg_ask_quantity
+        $this->assertEquals(
+            'How many seniors did you swap stories with?',
+            $campaign->msg_ask_quantity
+        );
+
+        // current_run
+        $this->assertEquals(7298, $campaign->current_run);
+
+        // mobilecommons_group_doing
+        $this->assertEquals(255742, $campaign->mobilecommons_group_doing);
+
+        // mobilecommons_group_completed
+        $this->assertEquals(255724, $campaign->mobilecommons_group_completed);
+
+        // mobilecommons_keywords
+        $this->assertInternalType('array', $campaign->mobilecommons_keywords);
+        $this->assertContainsOnly('string', $campaign->mobilecommons_keywords);
+        $this->assertEquals(['SWAPBOT'], $campaign->mobilecommons_keywords);
+    }
+
+}

--- a/tests/GambitTest.php
+++ b/tests/GambitTest.php
@@ -2,13 +2,35 @@
 
 use DoSomething\GatewayTests\Helpers\JsonResponse;
 use DoSomething\GatewayTests\Helpers\Gambit\CampaignResponse;
-// use DoSomething\GatewayTests\Helpers\Gambit\CampaignsResponse;
+use DoSomething\GatewayTests\Helpers\Gambit\CampaignsResponse;
 
 class GambitTest extends PHPUnit_Framework_TestCase
 {
     protected $defaultConfig = [
         'url' => 'https://gambit-phpunit.dosomething.org', // not a real server!
     ];
+
+    /**
+     * Test that we can use the all campaigns endpoint.
+     */
+    public function testGetAllCampaigns()
+    {
+        $restClient = new MockGambit($this->defaultConfig, [
+            new CampaignsResponse,
+        ]);
+
+        $campaigns = $restClient->getAllCampaigns();
+
+        // It should successfully serialize into a collection.
+        $this->assertInstanceOf(\DoSomething\Gateway\Common\ApiCollection::class, $campaigns);
+
+        // Test correct campaigns count.
+        $this->assertEquals(2, $campaigns->count());
+
+        // And we should be able to traverse and read values from that.
+        $this->assertEquals('Don\'t Be a Sucker', $campaigns[0]->title);
+        $this->assertEquals('Senior Story Swap', $campaigns[1]->title);
+    }
 
     /**
      * Test that we can retrieve a campaign by their ID.

--- a/tests/Helpers/Gambit/CampaignResponse.php
+++ b/tests/Helpers/Gambit/CampaignResponse.php
@@ -11,7 +11,8 @@ class CampaignResponse extends JsonResponse
      */
     public function __construct($code = 200)
     {
-        $body = ['data' => [
+        $body = [];
+        $body['data'] = [
             'id' => 4944,
             'rb_verb' => 'Swappin Stories',
             'rb_noun' => 'Seniors',
@@ -24,8 +25,7 @@ class CampaignResponse extends JsonResponse
             'mobilecommons_group_doing' => 255742,
             'mobilecommons_group_completed' => 255724,
             'mobilecommons_keywords' => ['SWAPBOT'],
-        ]];
-
+        ];
         parent::__construct($body, $code);
     }
 }

--- a/tests/Helpers/Gambit/CampaignResponse.php
+++ b/tests/Helpers/Gambit/CampaignResponse.php
@@ -7,7 +7,7 @@ use DoSomething\GatewayTests\Helpers\JsonResponse;
 class CampaignResponse extends JsonResponse
 {
     /**
-     * Make a new mock user response.
+     * Make a new mock Gambit campaign by id response.
      */
     public function __construct($code = 200)
     {

--- a/tests/Helpers/Gambit/CampaignResponse.php
+++ b/tests/Helpers/Gambit/CampaignResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DoSomething\GatewayTests\Helpers\Gambit;
+
+use DoSomething\GatewayTests\Helpers\JsonResponse;
+
+class CampaignResponse extends JsonResponse
+{
+    /**
+     * Make a new mock user response.
+     */
+    public function __construct($code = 200)
+    {
+        $body = ['data' => [
+            'id' => 4944,
+            'rb_verb' => 'Swappin Stories',
+            'rb_noun' => 'Seniors',
+            'msg_rb_confirmation' => 'Wait, your Grandma did WHAT? Thanks for playing and swapping stories!',
+            'title' => 'Senior Story Swap',
+            'tagline' => 'Swap stories with an older adult to decrease isolation.',
+            'status' => 'closed',
+            'msg_ask_quantity' => 'How many seniors did you swap stories with?',
+            'current_run' => 7298,
+            'mobilecommons_group_doing' => 255742,
+            'mobilecommons_group_completed' => 255724,
+            'mobilecommons_keywords' => ['SWAPBOT'],
+        ]];
+
+        parent::__construct($body, $code);
+    }
+}

--- a/tests/Helpers/Gambit/CampaignsResponse.php
+++ b/tests/Helpers/Gambit/CampaignsResponse.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace DoSomething\GatewayTests\Helpers\Gambit;
+
+use DoSomething\GatewayTests\Helpers\JsonResponse;
+
+class CampaignsResponse extends JsonResponse
+{
+    /**
+     * Make a new mock user response.
+     */
+    public function __construct($code = 200)
+    {
+        $body = ['data' => [
+            [
+                'id' => 46,
+                'rb_noun' => 'Vampires',
+                'rb_verb' => 'Unplugged',
+                'msg_rb_confirmation' => 'You SLAYED this campaign. Badass. ',
+                'title' => 'Don\'t Be a Sucker',
+                'tagline' => 'Unplug unused electronics to conserve energy.',
+                'status' => '6196',
+                'current_run' => 6196,
+                'mobilecommons_group_doing' => 255889,
+                'mobilecommons_group_completed' => 255886,
+                'mobilecommons_keywords' => ['suckerbot'],
+            ],
+            [
+                'id' => 4944,
+                'rb_verb' => 'Swappin Stories',
+                'rb_noun' => 'Seniors',
+                'msg_rb_confirmation' => 'Wait, your Grandma did WHAT? Thanks for playing and swapping stories!',
+                'title' => 'Senior Story Swap',
+                'tagline' => 'Swap stories with an older adult to decrease isolation.',
+                'status' => 'closed',
+                'msg_ask_quantity' => 'How many seniors did you swap stories with?',
+                'current_run' => 7298,
+                'mobilecommons_group_doing' => 255742,
+                'mobilecommons_group_completed' => 255724,
+                'mobilecommons_keywords' => ['SWAPBOT'],
+            ],
+        ]];
+
+        parent::__construct($body, $code);
+    }
+}

--- a/tests/Helpers/Gambit/CampaignsResponse.php
+++ b/tests/Helpers/Gambit/CampaignsResponse.php
@@ -7,7 +7,7 @@ use DoSomething\GatewayTests\Helpers\JsonResponse;
 class CampaignsResponse extends JsonResponse
 {
     /**
-     * Make a new mock user response.
+     * Make a new mock Gambit list all campaigns response.
      */
     public function __construct($code = 200)
     {

--- a/tests/Helpers/Gambit/CampaignsResponse.php
+++ b/tests/Helpers/Gambit/CampaignsResponse.php
@@ -11,36 +11,34 @@ class CampaignsResponse extends JsonResponse
      */
     public function __construct($code = 200)
     {
-        $body = ['data' => [
-            [
-                'id' => 46,
-                'rb_noun' => 'Vampires',
-                'rb_verb' => 'Unplugged',
-                'msg_rb_confirmation' => 'You SLAYED this campaign. Badass. ',
-                'title' => 'Don\'t Be a Sucker',
-                'tagline' => 'Unplug unused electronics to conserve energy.',
-                'status' => '6196',
-                'current_run' => 6196,
-                'mobilecommons_group_doing' => 255889,
-                'mobilecommons_group_completed' => 255886,
-                'mobilecommons_keywords' => ['suckerbot'],
-            ],
-            [
-                'id' => 4944,
-                'rb_verb' => 'Swappin Stories',
-                'rb_noun' => 'Seniors',
-                'msg_rb_confirmation' => 'Wait, your Grandma did WHAT? Thanks for playing and swapping stories!',
-                'title' => 'Senior Story Swap',
-                'tagline' => 'Swap stories with an older adult to decrease isolation.',
-                'status' => 'closed',
-                'msg_ask_quantity' => 'How many seniors did you swap stories with?',
-                'current_run' => 7298,
-                'mobilecommons_group_doing' => 255742,
-                'mobilecommons_group_completed' => 255724,
-                'mobilecommons_keywords' => ['SWAPBOT'],
-            ],
-        ]];
-
+        $body = [];
+        $body['data'][] = [
+            'id' => 46,
+            'rb_noun' => 'Vampires',
+            'rb_verb' => 'Unplugged',
+            'msg_rb_confirmation' => 'You SLAYED this campaign. Badass. ',
+            'title' => 'Don\'t Be a Sucker',
+            'tagline' => 'Unplug unused electronics to conserve energy.',
+            'status' => '6196',
+            'current_run' => 6196,
+            'mobilecommons_group_doing' => 255889,
+            'mobilecommons_group_completed' => 255886,
+            'mobilecommons_keywords' => ['suckerbot'],
+        ];
+        $body['data'][] = [
+            'id' => 4944,
+            'rb_verb' => 'Swappin Stories',
+            'rb_noun' => 'Seniors',
+            'msg_rb_confirmation' => 'Wait, your Grandma did WHAT? Thanks for playing and swapping stories!',
+            'title' => 'Senior Story Swap',
+            'tagline' => 'Swap stories with an older adult to decrease isolation.',
+            'status' => 'closed',
+            'msg_ask_quantity' => 'How many seniors did you swap stories with?',
+            'current_run' => 7298,
+            'mobilecommons_group_doing' => 255742,
+            'mobilecommons_group_completed' => 255724,
+            'mobilecommons_keywords' => ['SWAPBOT'],
+        ];
         parent::__construct($body, $code);
     }
 }

--- a/tests/Helpers/Gambit/CampaignsResponse.php
+++ b/tests/Helpers/Gambit/CampaignsResponse.php
@@ -19,7 +19,7 @@ class CampaignsResponse extends JsonResponse
             'msg_rb_confirmation' => 'You SLAYED this campaign. Badass. ',
             'title' => 'Don\'t Be a Sucker',
             'tagline' => 'Unplug unused electronics to conserve energy.',
-            'status' => '6196',
+            'status' => 'active',
             'current_run' => 6196,
             'mobilecommons_group_doing' => 255889,
             'mobilecommons_group_completed' => 255886,

--- a/tests/Mocks/MockGambit.php
+++ b/tests/Mocks/MockGambit.php
@@ -1,0 +1,24 @@
+<?php
+
+use DoSomething\Gateway\Gambit;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+
+class MockGambit extends Gambit
+{
+    /**
+     * MockClient constructor.
+     *
+     * @param array $config
+     * @param array $responses - PSR responses to be returned, in order.
+     */
+    public function __construct($config, $responses)
+    {
+        $mock = new MockHandler($responses);
+        $handler = HandlerStack::create($mock);
+
+        $config = array_merge($config, ['handler' => $handler]);
+
+        parent::__construct($config, ['handler' => $handler]);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?

Implements Campaign endpoints of [Gambit API](https://github.com/DoSomething/gambit/tree/develop/documentation):
- [`GET /v1/campaigns`](http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns): `Gambit::getAllCampaigns()`
- [`GET /v1/campaigns/:id`](http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns/4944): `Gambit:: getCampaign($id)`
- Covers API with corresponding unit tests using Mock objects
#### Any background context you want to provide?

Current Gambit response are yet to be normalized, see DoSomething/gambit#681.
#### Todo

Todo: `POST /v1/chatbot`
#### Where should the reviewer start?
- @weerd Please review integration with Gateway
- @aaronschachter Please review integration with Gambit
- @deadlybutter CC
#### What are the relevant tickets?

Ref DoSomething/mbc-registration-email#71.
