### PR TITLE
Fix Gambit signups endpoint typo.

### DIFF
--- a/src/Gambit.php
+++ b/src/Gambit.php
@@ -89,7 +89,7 @@ class Gambit extends RestApiClient
             'id' => $id,
             'source' => $source,
         ];
-        $response = $this->post('v1/signup/', $payload);
+        $response = $this->post('v1/signups/', $payload);
 
         if (is_null($response) || ! $this->responseSuccessful($response)) {
             return false;


### PR DESCRIPTION
This fixes small typo introduced in #57.
Gambit create signup endpoint is actually `signups` (plural), not `signup`.
