### PR TITLE
Only check model interfaces if one is provided.

### DIFF
--- a/src/Laravel/LaravelOAuthBridge.php
+++ b/src/Laravel/LaravelOAuthBridge.php
@@ -23,8 +23,7 @@ class LaravelOAuthBridge implements OAuthBridgeContract
     {
         $this->model = config('auth.model');
 
-        $interfaces = class_implements($this->model);
-        if (! in_array(NorthstarUserContract::class, $interfaces)) {
+        if (! empty($this->model) && ! in_array(NorthstarUserContract::class, class_implements($this->model))) {
             throw new InvalidArgumentException('The auth.user model must use the HasNorthstarToken trait & the NorthstarUserContract interface.');
         }
     }


### PR DESCRIPTION
#### Changes
We currently check that the provided user implements `NorthstarUserContract` when setting up the OAuth repository. This is a nice safety precaution when we know we have a user class, but for apps without users it gets in the way.

This update makes the repository only check the classes' implemented interfaces if one is provided.

---
For review: @weerd