### PR TITLE
Indexes must be dropped by _index_ name, not column name!

### DIFF
--- a/src/Laravel/Migrations/2016_06_29_205018_add_oauth_fields_to_users.php
+++ b/src/Laravel/Migrations/2016_06_29_205018_add_oauth_fields_to_users.php
@@ -33,7 +33,7 @@ class AddOauthFieldsToUsers extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropIndex('northstar_id');
+            $table->dropIndex('users_northstar_id_unique');
             $table->dropColumn('northstar_id');
 
             $table->dropColumn('access_token');


### PR DESCRIPTION
#### Changes
A little mystery, solved! Rollbacks were failing on this migration because it couldn't find an index with the name `northstar_id` to remove... turns out, that's not how indexes work. The more you know! ✨

---
For review: @weerd