### PR TITLE
Transaction id clarification in doc block

### DIFF
--- a/src/ForwardsTransactionIds.php
+++ b/src/ForwardsTransactionIds.php
@@ -6,6 +6,8 @@ trait ForwardsTransactionIds
 {
     /**
      * Run custom tasks before making a request.
+     * Note: the below only sets up transaction id logic when making a request.
+     * Each app must do own logic to increment and log received transaction ids.
      *
      * @see RestApiClient@raw
      */


### PR DESCRIPTION
This PR adds a comment to clarify that transaction id trait only contains logic to increment and log transaction ids when request are made, not received. Individual apps are responsible for incrementing and logging received requests in their own logs.