### PR TITLE
Misc. fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.editorconfig     export-ignore
+.gitattributes    export-ignore
+phpunit.xml       export-ignore
+wercker.yml       export-ignore
+/tests/           export-ignore

--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -127,6 +127,9 @@ trait AuthorizesWithNorthstar
      */
     public function authorize(ServerRequestInterface $request, ResponseInterface $response, $destination = '/')
     {
+        // Make sure we're making request with the authorization_code grant.
+        $this->asUser();
+
         $destination = $this->getFrameworkBridge()->prepareUrl($destination);
         $query = $request->getQueryParams();
 
@@ -170,6 +173,9 @@ trait AuthorizesWithNorthstar
      */
     public function logout(ResponseInterface $response, $destination = '/')
     {
+        // Make sure we're making request with the authorization_code grant.
+        $this->asUser();
+
         $this->getFrameworkBridge()->logout();
 
         $destination = $this->getFrameworkBridge()->prepareUrl($destination);

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -15,6 +15,6 @@ class ApiException extends Exception
      */
     public function __construct($endpoint, $code, $message)
     {
-        parent::__construct('Exception in Northstar "'.$endpoint.'" endpoint: ['.$code.'] '.$message);
+        parent::__construct('Exception from "'.$endpoint.'": ['.$code.'] '.$message, $code);
     }
 }

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -7,6 +7,13 @@ use Exception;
 class ApiException extends Exception
 {
     /**
+     * The endpoint that triggered the error.
+     *
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
      * Make a new generic API exception.
      *
      * @param string $endpoint
@@ -15,6 +22,18 @@ class ApiException extends Exception
      */
     public function __construct($endpoint, $code, $message)
     {
+        $this->endpoint = $endpoint;
+
         parent::__construct('Exception from "'.$endpoint.'": ['.$code.'] '.$message, $code);
+    }
+
+    /**
+     * Return the endpoint which triggered the error.
+     *
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint;
     }
 }


### PR DESCRIPTION
A little assortment of fixes and improvements:

🚳 Ignores development files (like the test directory) when installing via Composer.

⚠️ Changes exception message to not imply all Gateway errors happen in Northstar. Fixes #63.

🔚 Adds a `getEndpoint()` method to find out what endpoint an error happened on w/o string parsing.

🔏 Makes sure the `authorize()` and `logout()` functions use the auth code grant. Fixes #48.