### PR TITLE
Allow Gambit campaigns filtering

### DIFF
--- a/src/Gambit.php
+++ b/src/Gambit.php
@@ -49,11 +49,16 @@ class Gambit extends RestApiClient
     /**
      * Send a GET request to return all campaigns.
      *
+     * @param string $query - Filter campaigns. Following parameters allowed:
+     *   - campaignbot: (boolean) Only campaigns with campaignbot enabled
+     *
+     * @see https://github.com/DoSomething/gambit/blob/develop/documentation/endpoints/campaigns.md
+     *
      * @return GambitCampaignCollection
      */
-    public function getAllCampaigns()
+    public function getAllCampaigns($query = [])
     {
-        $response = $this->get('v1/campaigns', [], false);
+        $response = $this->get('v1/campaigns', $query, false);
 
         return new GambitCampaignCollection($response);
     }


### PR DESCRIPTION
#### What's this PR do?
- Allows Gambit campaigns filtering

#### Any background context you want to provide?
Now it's possible to load only campaigns with campaignbot enabled.

```php
$gambitCampaigns = $gambit->getAllCampaigns(['campaignbot'] => true);
```