### PR TITLE
Increase default token field lengths.

### DIFF
--- a/src/Laravel/Migrations/2017_05_16_104632_increase_token_field_length.php
+++ b/src/Laravel/Migrations/2017_05_16_104632_increase_token_field_length.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class IncreaseTokenFieldLength extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('access_token', 2048)->change();
+            $table->string('refresh_token', 2048)->change();
+        });
+
+        Schema::table('clients', function (Blueprint $table) {
+            $table->string('access_token', 2048)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('access_token', 1024)->change();
+            $table->string('refresh_token', 1024)->change();
+        });
+
+        Schema::table('clients', function (Blueprint $table) {
+            $table->string('access_token', 1024)->change();
+        });
+    }
+}


### PR DESCRIPTION
This pull request adds a migration to increase the length of the token fields, since Northstar will be generating longer tokens in the future when we [increase the key length](https://trello.com/c/qLn2nRFR/590-2-as-a-developer-i-want-to-increase-the-key-length-for-northstar-tokens).