### PR TITLE
Gladiator Integration

### DIFF
--- a/src/AuthorizesWithGladiator.php
+++ b/src/AuthorizesWithGladiator.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace DoSomething\Gateway;
+
+trait AuthorizesWithGladiator
+{
+    /**
+     * ApiKey.
+     *
+     * @var string
+     */
+    protected $apiKey;
+
+    /**
+     * Run custom tasks before making a request.
+     *
+     * @see RestApiClient@raw
+     */
+    protected function runAuthorizesWithGladiatorTasks($method, &$path, &$options, &$withAuthorization)
+    {
+        // By default, we append the authorization header to every request.
+        if ($withAuthorization) {
+            $authorizationHeader = $this->getAuthorizationHeader();
+            if (empty($options['headers'])) {
+                $options['headers'] = [];
+            }
+
+            $options['headers'] = array_merge($this->defaultHeaders, $options['headers'], $authorizationHeader);
+        }
+    }
+
+    /**
+     * Get the authorization header for a request
+     *
+     * @return null|array
+     * @throws \Exception
+     */
+    protected function getAuthorizationHeader()
+    {
+        if (empty($this->apiKey)) {
+            throw new \Exception('Gladiator API key is not set.');
+        }
+
+        return ['X-DS-Gladiator-API-Key' => $this->apiKey];
+    }
+}

--- a/src/Gladiator.php
+++ b/src/Gladiator.php
@@ -48,7 +48,7 @@ class Gladiator extends RestApiClient
      *
      * @return bool
      */
-    public function storeUserInContest(string $userId, $campaignId, $campaignRunId)
+    public function storeUserInContest($userId, $campaignId, $campaignRunId)
     {
         $response = $this->post('v1/users', [
             'id' => $userId,
@@ -69,7 +69,7 @@ class Gladiator extends RestApiClient
      *
      * @return bool
      */
-    public function unsubscribeUser(string $userId, $competition_id)
+    public function unsubscribeUser($userId, $competition_id)
     {
         $response = $this->post('v1/unsubscribe', [
             'northstar_id' => $userId,
@@ -78,5 +78,16 @@ class Gladiator extends RestApiClient
 
         // TODO: throw an exception if the post returns a validation error.
         return $this->responseSuccessful($response);
+    }
+
+    /**
+     * Determine if the response was successful or not.
+     *
+     * @param mixed $json
+     * @return bool
+     */
+    public function responseSuccessful($json)
+    {
+        return ! empty($json['data']);
     }
 }

--- a/src/Gladiator.php
+++ b/src/Gladiator.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace DoSomething\Gateway;
+
+use DoSomething\Gateway\Common\RestApiClient;
+
+class Gladiator extends RestApiClient
+{
+    use AuthorizesWithGladiator;
+
+    /**
+     * Configuration array.
+     *
+     * @var string
+     */
+    protected $config;
+
+    /**
+     * Default headers applied to every request.
+     *
+     * @var array
+     */
+    protected $defaultHeaders;
+
+    /**
+     * Create a new Gladiator API client.
+     * @param array $config
+     * @param array $overrides
+     */
+    public function __construct($config = [], $overrides = [])
+    {
+        // Save configuration.
+        $this->config = $config;
+
+        // Set response header.
+        if (! empty($config['gladiator_api_key'])) {
+            $this->apiKey = $config['gladiator_api_key'];
+        }
+        parent::__construct($config['url'], $overrides);
+    }
+
+    /**
+     * Send a POST request Gladiator to add user to a contest.
+     *
+     * @param  string $userId
+     * @param  string $campaignId
+     * @param  string $campaignRunId
+     *
+     * @return bool
+     */
+    public function storeUserInContest(string $userId, $campaignId, $campaignRunId)
+    {
+        $response = $this->post('v1/users', [
+            'id' => $userId,
+            'term' => 'id',
+            'campaign_id' => $legacyCampaignId,
+            'campaign_run_id' => $legacyCampaignRunId,
+        ]);
+
+        // TODO: throw an exception if the post returns a validation error.
+        return $this->responseSuccessful($response);
+    }
+
+    /**
+     * Send a POST request Gladiator unsubscribe users from competition messages.
+     *
+     * @param  string $userId
+     * @param  string $competitionId
+     *
+     * @return bool
+     */
+    public function unsubscribeUser(string $userId, $competition_id)
+    {
+        $response = $this->post('v1/unsubscribe', [
+            'northstar_id' => $userId,
+            'competition_id' => $competition_id,
+        ]);
+
+        // TODO: throw an exception if the post returns a validation error.
+        return $this->responseSuccessful($response);
+    }
+}

--- a/src/Gladiator.php
+++ b/src/Gladiator.php
@@ -57,7 +57,6 @@ class Gladiator extends RestApiClient
             'campaign_run_id' => $legacyCampaignRunId,
         ]);
 
-        // TODO: throw an exception if the post returns a validation error.
         return $this->responseSuccessful($response);
     }
 
@@ -76,7 +75,6 @@ class Gladiator extends RestApiClient
             'competition_id' => $competition_id,
         ]);
 
-        // TODO: throw an exception if the post returns a validation error.
         return $this->responseSuccessful($response);
     }
 

--- a/src/Gladiator.php
+++ b/src/Gladiator.php
@@ -88,6 +88,6 @@ class Gladiator extends RestApiClient
      */
     public function responseSuccessful($json)
     {
-        return ! empty($json['data']);
+        return ! empty($json['data']) || ! empty($json['message']);
     }
 }

--- a/tests/GladiatorTest.php
+++ b/tests/GladiatorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use DoSomething\GatewayTests\Helpers\Gladiator\StoreUserResponse;
+
+class GladiatorTest extends PHPUnit_Framework_TestCase
+{
+    protected $defaultConfig = [
+        'url' => 'https://gladiator-test.dosomething.org', // not a real server!
+    ];
+    protected $authorizedConfig = [
+        'url' => 'https://gladiator-test.dosomething.org', // not a real server!
+        'gladiator_api_key' => 'gladiator_api_key',
+    ];
+
+    /**
+     * Test that we can store users in Gladiator.
+     */
+    public function testStoringAUser()
+    {
+        $restClient = new MockGladiator($this->authorizedConfig, [
+            new StoreUserResponse,
+        ]);
+
+        $user = $restClient->storeUserInContest("550200bba39awieg467a3cg2", "6749", "2039");
+
+        $this->assertTrue($user);
+    }
+}

--- a/tests/GladiatorTest.php
+++ b/tests/GladiatorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use DoSomething\GatewayTests\Helpers\Gladiator\StoreUserResponse;
+use DoSomething\GatewayTests\Helpers\Gladiator\UnsubscribeUserResponse;
 
 class GladiatorTest extends PHPUnit_Framework_TestCase
 {
@@ -21,8 +22,19 @@ class GladiatorTest extends PHPUnit_Framework_TestCase
             new StoreUserResponse,
         ]);
 
-        $user = $restClient->storeUserInContest("550200bba39awieg467a3cg2", "6749", "2039");
+        $user = $restClient->storeUserInContest('550200bba39awieg467a3cg2', '6749', '2039');
 
         $this->assertTrue($user);
+    }
+
+    public function testUnsubscribingAUser()
+    {
+        $restClient = new MockGladiator($this->authorizedConfig, [
+            new UnsubscribeUserResponse,
+        ]);
+
+        $response = $restClient->unsubscribeUser('550200bba39awieg467a3cg2', '6749');
+
+        $this->assertTrue($response);
     }
 }

--- a/tests/Helpers/Gladiator/StoreUserResponse.php
+++ b/tests/Helpers/Gladiator/StoreUserResponse.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DoSomething\GatewayTests\Helpers\Gladiator;
+
+use DoSomething\GatewayTests\Helpers\JsonResponse;
+
+class StoreUserResponse extends JsonResponse
+{
+    /**
+     * Make a new mock Gladiator store user response.
+     */
+    public function __construct($code = 200)
+    {
+        $body = [];
+        $body['data'] = [
+            'id' => "550200bba39awieg467a3cg2",
+            'first_name' => null,
+            'last_name' => null,
+            'email' => null,
+            'mobile' => null,
+            'signup' => null,
+            'reportback' => null,
+            'created_at' => "2016-03-08T18:27:10+0000",
+            'updated_at' => "2016-03-08T18:27:10+0000"
+        ];
+        parent::__construct($body, $code);
+    }
+}

--- a/tests/Helpers/Gladiator/StoreUserResponse.php
+++ b/tests/Helpers/Gladiator/StoreUserResponse.php
@@ -13,15 +13,15 @@ class StoreUserResponse extends JsonResponse
     {
         $body = [];
         $body['data'] = [
-            'id' => "550200bba39awieg467a3cg2",
+            'id' => '550200bba39awieg467a3cg2',
             'first_name' => null,
             'last_name' => null,
             'email' => null,
             'mobile' => null,
             'signup' => null,
             'reportback' => null,
-            'created_at' => "2016-03-08T18:27:10+0000",
-            'updated_at' => "2016-03-08T18:27:10+0000"
+            'created_at' => '2016-03-08T18:27:10+0000',
+            'updated_at' => '2016-03-08T18:27:10+0000',
         ];
         parent::__construct($body, $code);
     }

--- a/tests/Helpers/Gladiator/UnsubscribeUserResponse.php
+++ b/tests/Helpers/Gladiator/UnsubscribeUserResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DoSomething\GatewayTests\Helpers\Gladiator;
+
+use DoSomething\GatewayTests\Helpers\JsonResponse;
+
+class UnsubscribeUserResponse extends JsonResponse
+{
+    /**
+     * Make a new mock Gladiator store user response.
+     */
+    public function __construct($code = 200)
+    {
+        $body = ['message' => 'success'];
+
+        parent::__construct($body, $code);
+    }
+}

--- a/tests/Mocks/MockGladiator.php
+++ b/tests/Mocks/MockGladiator.php
@@ -1,0 +1,24 @@
+<?php
+
+use DoSomething\Gateway\Gladiator;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+
+class MockGladiator extends Gladiator
+{
+    /**
+     * MockClient constructor.
+     *
+     * @param array $config
+     * @param array $responses - PSR responses to be returned, in order.
+     */
+    public function __construct($config, $responses)
+    {
+        $mock = new MockHandler($responses);
+        $handler = HandlerStack::create($mock);
+
+        $config = array_merge($config, ['handler' => $handler]);
+
+        parent::__construct($config, ['handler' => $handler]);
+    }
+}


### PR DESCRIPTION
#### What's this PR do?

This PR adds gladiator support to Gateway. It covers two main endpoints,  `POST /users` endpoint that stores users in gladiator and `POST /unsubscribe` that unsubscribes them from competition messaging.

I left out support for the `GET /users` endpoint as I think there was some discussion around changing the response on that endpoint and want to get that worked out first. 

Also adds test coverage for Gladiator in Gateway. 

#### How should this be reviewed?

Commit by commit, run unit tests

#### Checklist
- [x] Tests added for new features/bug fixes.
- [ ] Post a message in #api if this includes something that causes a rebuild!  
