### PR TITLE
Adding options array

### DIFF
--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -123,10 +123,11 @@ trait AuthorizesWithNorthstar
      * @param ResponseInterface $response
      * @param string $url - The destination URL to redirect to on a successful login.
      * @param string $destination - the title for the post-login destination
+     * @param array  $options - Array of options to apply
      * @return ResponseInterface
      * @throws InternalException
      */
-    public function authorize(ServerRequestInterface $request, ResponseInterface $response, $url = '/', $destination = null)
+    public function authorize(ServerRequestInterface $request, ResponseInterface $response, $url = '/', $destination = null, $options = []) // TODO: Merge $url & $destination into $options
     {
         // Make sure we're making request with the authorization_code grant.
         $this->asUser();
@@ -136,10 +137,11 @@ trait AuthorizesWithNorthstar
 
         // If we don't have an authorization code then make one and redirect.
         if (! isset($query['code'])) {
-            $authorizationUrl = $this->getAuthorizationServer()->getAuthorizationUrl([
+            $params = array_merge($options, [
                 'scope' => $this->config['authorization_code']['scope'],
                 'destination' => ! empty($destination) ? $destination : null,
             ]);
+            $authorizationUrl = $this->getAuthorizationServer()->getAuthorizationUrl($params);
 
             // Get the state generated for you and store it to the session.
             $state = $this->getAuthorizationServer()->getState();

--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -119,6 +119,8 @@ trait AuthorizesWithNorthstar
     /**
      * Handle the OpenID Connect authorization flow.
      *
+     * @TODO: Merge $url & $destination into $options
+     *
      * @param ServerRequestInterface $request
      * @param ResponseInterface $response
      * @param string $url - The destination URL to redirect to on a successful login.
@@ -127,7 +129,7 @@ trait AuthorizesWithNorthstar
      * @return ResponseInterface
      * @throws InternalException
      */
-    public function authorize(ServerRequestInterface $request, ResponseInterface $response, $url = '/', $destination = null, $options = []) // TODO: Merge $url & $destination into $options
+    public function authorize(ServerRequestInterface $request, ResponseInterface $response, $url = '/', $destination = null, $options = [])
     {
         // Make sure we're making request with the authorization_code grant.
         $this->asUser();


### PR DESCRIPTION
This PR adds an optional array of options that Northstar can ingest for customizing the login experience. For example, a custom header photo. 

Eventually, this should replace the $url and $destination method params 

Here is an example output from p-n 

```
Array ( [test] => hi diego [scope] => Array ( [0] => user [1] => openid [2] => role:staff [3] => role:admin ) [destination] => Teens for Jeans Testing )
```