### PR TITLE
Allow Gateway apps to optimistically update access token.

### DIFF
--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -325,6 +325,26 @@ trait AuthorizesWithNorthstar
     }
 
     /**
+     * If a user is logged in & has an expired access token,
+     * fetch a new one using their refresh token.
+     *
+     * @return void
+     */
+    public function refreshIfExpired()
+    {
+        $user = $this->getFrameworkBridge()->getCurrentUser();
+
+        if (! $user) {
+            return null;
+        }
+
+        $token = $user->getOAuthToken();
+        if ($token && $token->hasExpired()) {
+            $this->refreshAccessToken($token);
+        }
+    }
+
+    /**
      * Get a new access token based on the chosen grant.
      *
      * @param $token

--- a/src/Laravel/GatewayServiceProvider.php
+++ b/src/Laravel/GatewayServiceProvider.php
@@ -4,6 +4,8 @@ namespace DoSomething\Gateway\Laravel;
 
 use Auth;
 use Illuminate\Http\Request;
+use DoSomething\Gateway\Blink;
+use DoSomething\Gateway\Gladiator;
 use DoSomething\Gateway\Northstar;
 use DoSomething\Gateway\Server\Token;
 use Illuminate\Support\ServiceProvider;
@@ -34,7 +36,20 @@ class GatewayServiceProvider extends ServiceProvider
             return new LaravelNorthstar(config('services.northstar'));
         });
 
+        $this->app->singleton(Blink::class, function () {
+            return new Blink(config('services.blink'));
+        });
+
+        $this->app->singleton(Gladiator::class, function () {
+            return new Gladiator(config('services.gladiator'));
+        });
+
         // Set alias for requesting from app() helper.
+        $this->app->alias(Northstar::class, 'gateway.northstar');
+        $this->app->alias(Blink::class, 'gateway.blink');
+        $this->app->alias(Gladiator::class, 'gateway.gladiator');
+
+        // Backwards-compatibility.
         $this->app->alias(Northstar::class, 'northstar');
 
         // Register token validator w/ config dependency.

--- a/src/Laravel/Middleware/RefreshTokenMiddleware.php
+++ b/src/Laravel/Middleware/RefreshTokenMiddleware.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DoSomething\Gateway\Laravel\Middleware;
+
+use Closure;
+use DoSomething\Gateway\Northstar;
+
+class RefreshTokenMiddleware
+{
+    /**
+     * The Northstar API client.
+     *
+     * @var Northstar
+     */
+    protected $northstar;
+
+    /**
+     * Create a new filter instance.
+     *
+     * @param  Northstar $northstar
+     */
+    public function __construct(Northstar $northstar)
+    {
+        $this->northstar = $northstar;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        // If a user is logged in with an expired access token, try to refresh it.
+        $this->northstar->refreshIfExpired();
+
+        return $next($request);
+    }
+}

--- a/src/Laravel/helpers.php
+++ b/src/Laravel/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Contracts\Container\BindingResolutionException;
 use DoSomething\Gateway\Common\RestApiClient;
 use DoSomething\Gateway\Server\Token;
 use DoSomething\Gateway\Northstar;
@@ -13,11 +14,11 @@ if (! function_exists('gateway')) {
      */
     function gateway($client)
     {
-        if ($client !== 'northstar') {
-            throw new InvalidArgumentException('There isn\'t a Gateway client registered with that name.');
+        try {
+            return app('gateway.'.$client);
+        } catch (BindingResolutionException $e) {
+            throw new InvalidArgumentException('There isn\'t a Gateway client registered as "'.$client.'".');
         }
-
-        return app(Northstar::class);
     }
 
     /**


### PR DESCRIPTION
### Changes
This pull request allows any application that uses Gateway to refresh the user's access token as soon as it expires – this saves a round-trip later (eh), and also means that we get accurate `last_accessed_at` timestamps on their Northstar profile.

References DoSomething/quasar#361.