### PR TITLE
Blink rogue integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,44 @@ $northstar->withToken($accessToken)->get('v1/profile');
 
 ```
 
+**Blink**
+
+This package includes basic API wrapper for [DoSomething/blink)(/DoSomething/blink).
+
+Usage is similar to the example above with an exception that it doesn't require using class bridge,
+but uses header HTTP Basic instead.
+
+```php
+use DoSomething\Gateway\Blink;
+
+// Create blink API object.
+$blink = new Blink([
+    'url' => 'https://blink.dosomething.org/api/',
+    'user' => 'blink',     // Replace with real blink username
+    'password' => 'blink', //Replace with real blink password
+]);
+
+// Send userSignup() event to blink with specified payload.
+$result = $blinkRestClient->userSignup([
+    'id' => 4036838,
+    'northstar_id' => '598ca42c10707d7680749f81',
+    'campaign_id' => 7,
+    'campaign_run_id' => 7818,
+    'quantity' => 12,
+    'quantity_pending' => null,
+    'why_participated' => 'I love to test!',
+    'source' => 'niche',
+    'created_at' => '2017-08-10 18:21:35',
+    'updated_at' => '2017-08-10 18:21:35',
+]);
+
+// $result variable would contain boolean response state,
+// but in most cases, it's safe to ignore it and assume that the operation
+// has been performed successfully.
+```
+
+For more call and usage examples see Blink and BlinkTest classes.
+
 ### Laravel Usage
 Laravel support is built-in. First, add the service provider to your `config/app.php`:
 
@@ -191,5 +229,5 @@ with the appropriate `northstar_id` and `role` columns. The user's access and re
 can make authorized requests to other DoSomething.org services.
 
 ### License
-&copy;2016 DoSomething.org. Gateway is free software, and may be redistributed under the terms
+&copy;2017 DoSomething.org. Gateway is free software, and may be redistributed under the terms
 specified in the [LICENSE](https://github.com/DoSomething/northstar-php/blob/master/LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ $northstar->withToken($accessToken)->get('v1/profile');
 
 This package includes basic API wrapper for [DoSomething/blink](https://github.com/DoSomething/blink).
 
-Usage is similar to the example above with an exception that it doesn't require using class bridge,
-and rely on HTTP Basic authentication instead.
+Usage is similar to the example above with an exception that it doesn't require using bridge class,
+and rely on HTTP Basic Authentication with by HTTP header instead.
 
 ```php
 use DoSomething\Gateway\Blink;

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ $northstar->withToken($accessToken)->get('v1/profile');
 
 **Blink**
 
-This package includes basic API wrapper for [DoSomething/blink)(/DoSomething/blink).
+This package includes basic API wrapper for [DoSomething/blink](/DoSomething/blink).
 
 Usage is similar to the example above with an exception that it doesn't require using class bridge,
-but uses header HTTP Basic instead.
+and rely on HTTP Basic authentication instead.
 
 ```php
 use DoSomething\Gateway\Blink;
@@ -86,8 +86,8 @@ $result = $blinkRestClient->userSignup([
     'updated_at' => '2017-08-10 18:21:35',
 ]);
 
-// $result variable would contain boolean response state,
-// but in most cases, it's safe to ignore it and assume that the operation
+// $result variable would contain boolean response state.
+// In most cases, it's safe to ignore it and assume that the operation
 // has been performed successfully.
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $result = $blinkRestClient->userSignup([
 // has been performed successfully.
 ```
 
-For more call and usage examples see Blink and BlinkTest classes.
+For more call and usage examples see [Blink](/DoSomething/gateway/blob/master/src/Blink.php) and [BlinkTest](/DoSomething/gateway/blob/master/tests/BlinkTest.php) classes.
 
 ### Laravel Usage
 Laravel support is built-in. First, add the service provider to your `config/app.php`:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $northstar->withToken($accessToken)->get('v1/profile');
 This package includes basic API wrapper for [DoSomething/blink](https://github.com/DoSomething/blink).
 
 Usage is similar to the example above with an exception that it doesn't require using bridge class,
-and rely on HTTP Basic Authentication with by HTTP header instead.
+and rely on HTTP Basic Authentication with HTTP header instead.
 
 ```php
 use DoSomething\Gateway\Blink;

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $northstar->withToken($accessToken)->get('v1/profile');
 
 **Blink**
 
-This package includes basic API wrapper for [DoSomething/blink](/DoSomething/blink).
+This package includes basic API wrapper for [DoSomething/blink](https://github.com/DoSomething/blink).
 
 Usage is similar to the example above with an exception that it doesn't require using class bridge,
 and rely on HTTP Basic authentication instead.
@@ -91,7 +91,7 @@ $result = $blinkRestClient->userSignup([
 // has been performed successfully.
 ```
 
-For more call and usage examples see [Blink](/DoSomething/gateway/blob/master/src/Blink.php) and [BlinkTest](/DoSomething/gateway/blob/master/tests/BlinkTest.php) classes.
+For more calls and usage examples see [Blink](https://github.com/DoSomething/gateway/blob/master/src/Blink.php) and [BlinkTest](https://github.com/DoSomething/gateway/blob/master/tests/BlinkTest.php) classes.
 
 ### Laravel Usage
 Laravel support is built-in. First, add the service provider to your `config/app.php`:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $blink = new Blink([
     'password' => 'blink', //Replace with real blink password
 ]);
 
-// Send userSignup() event to blink with specified payload.
+// Send user signup event to blink with specified data payload.
 $result = $blinkRestClient->userSignup([
     'id' => 4036838,
     'northstar_id' => '598ca42c10707d7680749f81',
@@ -86,9 +86,9 @@ $result = $blinkRestClient->userSignup([
     'updated_at' => '2017-08-10 18:21:35',
 ]);
 
-// $result variable would contain boolean response state.
+// $result variable will contain boolean response state.
 // In most cases, it's safe to ignore it and assume that the operation
-// has been performed successfully.
+// was completed successfully.
 ```
 
 For more calls and usage examples see [Blink](https://github.com/DoSomething/gateway/blob/master/src/Blink.php) and [BlinkTest](https://github.com/DoSomething/gateway/blob/master/tests/BlinkTest.php) classes.

--- a/src/Blink.php
+++ b/src/Blink.php
@@ -62,7 +62,7 @@ class Blink extends RestApiClient
     /**
      * Send a Post request Blink /events/user-signup endpoint.
      *
-     * To notify Blink that Northstar user has been created.
+     * To notify Blink that Rogue signup has been created.
      *
      * @param array $signup - The array containing Rogue signup fields.
      * @see  https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/signups.md
@@ -71,6 +71,23 @@ class Blink extends RestApiClient
     public function userSignup(array $signup)
     {
         $response = $this->post('v1/events/user-signup', $signup);
+
+        // TODO: throw an exception if the post returns a validation error.
+        return $this->responseSuccessful($response);
+    }
+
+    /**
+     * Send a Post request Blink /events/user-signup endpoint.
+     *
+     * To notify Blink that Rogue signup psot has been created.
+     *
+     * @param array $signup - The array containing Rogue signup post fields.
+     * @see  https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/posts.md
+     * @return bool
+     */
+    public function userSignupPost(array $signupPost)
+    {
+        $response = $this->post('v1/events/user-signup-post', $signupPost);
 
         // TODO: throw an exception if the post returns a validation error.
         return $this->responseSuccessful($response);

--- a/src/Blink.php
+++ b/src/Blink.php
@@ -79,7 +79,7 @@ class Blink extends RestApiClient
     /**
      * Send a Post request Blink /events/user-signup endpoint.
      *
-     * To notify Blink that Rogue signup psot has been created.
+     * To notify Blink that Rogue signup post has been created.
      *
      * @param array $signup - The array containing Rogue signup post fields.
      * @see  https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/posts.md

--- a/src/Blink.php
+++ b/src/Blink.php
@@ -60,6 +60,23 @@ class Blink extends RestApiClient
     }
 
     /**
+     * Send a Post request Blink /events/user-create endpoint.
+     *
+     * To notify Blink that Northstar user has been created.
+     *
+     * @param array $signup - The array containing Rogue signup fields.
+     * @see  https://github.com/DoSomething/rogue/blob/master/documentation/endpoints/signups.md
+     * @return bool
+     */
+    public function userSignup(array $signup)
+    {
+        $response = $this->post('v1/events/user-signup', $signup);
+
+        // TODO: throw an exception if the post returns a validation error.
+        return $this->responseSuccessful($response);
+    }
+
+    /**
      * Determine if the response was successful or not.
      *
      * @param mixed $json

--- a/src/Blink.php
+++ b/src/Blink.php
@@ -60,7 +60,7 @@ class Blink extends RestApiClient
     }
 
     /**
-     * Send a Post request Blink /events/user-create endpoint.
+     * Send a Post request Blink /events/user-signup endpoint.
      *
      * To notify Blink that Northstar user has been created.
      *

--- a/tests/BlinkTest.php
+++ b/tests/BlinkTest.php
@@ -78,7 +78,7 @@ class BlinkTest extends PHPUnit_Framework_TestCase
     public function testUserSignupPostCreate()
     {
         // Input data.
-        $rogueReportbackPayload = [
+        $rogueSignupPostPayload = [
             'id' => 297635,
             'signup_id' => 4036823,
             'campaign_id' => 7831,
@@ -97,7 +97,7 @@ class BlinkTest extends PHPUnit_Framework_TestCase
             new BlinkResponse,
         ]);
 
-        $result = $blinkRestClient->userSignupPost($rogueReportbackPayload);
+        $result = $blinkRestClient->userSignupPost($rogueSignupPostPayload);
         $this->assertTrue($result);
     }
 }

--- a/tests/BlinkTest.php
+++ b/tests/BlinkTest.php
@@ -73,29 +73,31 @@ class BlinkTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test that we can notify blink of user campaign reporback.
+     * Test that we can notify blink of user signup post (AKA campaign reporback).
      */
-    public function testUserReportback()
+    public function testUserSignupPost()
     {
         // Input data.
         $rogueReportbackPayload = [
-            'id' => 4036838,
-            'northstar_id' => '598ca42c10707d7680749f81',
-            'campaign_id' => 7,
-            'campaign_run_id' => 7818,
-            'quantity' => 12,
-            'quantity_pending' => null,
-            'why_participated' => 'I love to test!',
-            'source' => 'niche',
-            'created_at' => '2017-08-10 18:21:35',
-            'updated_at' => '2017-08-10 18:21:35',
+            "id" => 297635,
+            "signup_id" => 4036823,
+            "campaign_id" => 7831,
+            "northstar_id" => "5564c93d469c6415048b8670",
+            "url" => "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/4036823-31b2064182a7fab7aa08d7e624faff0a-1501790315.jpeg",
+            "caption" => "test",
+            "status" => "pending",
+            "source" => "phoenix-next",
+            "remote_addr" => "104.156.90.29",
+            "created_at" => "2017-08-03 19:58:35",
+            "updated_at" => "2017-08-03 19:58:35",
+            "deleted_at" => null,
         ];
 
         $blinkRestClient = new MockBlink($this->authorizedConfig, [
             new BlinkResponse,
         ]);
 
-        $result = $blinkRestClient->userReporback($rogueReportbackPayload);
+        $result = $blinkRestClient->userSignupPost($rogueReportbackPayload);
         $this->assertTrue($result);
     }
 }

--- a/tests/BlinkTest.php
+++ b/tests/BlinkTest.php
@@ -79,18 +79,18 @@ class BlinkTest extends PHPUnit_Framework_TestCase
     {
         // Input data.
         $rogueReportbackPayload = [
-            "id" => 297635,
-            "signup_id" => 4036823,
-            "campaign_id" => 7831,
-            "northstar_id" => "5564c93d469c6415048b8670",
-            "url" => "https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/4036823-31b2064182a7fab7aa08d7e624faff0a-1501790315.jpeg",
-            "caption" => "test",
-            "status" => "pending",
-            "source" => "phoenix-next",
-            "remote_addr" => "104.156.90.29",
-            "created_at" => "2017-08-03 19:58:35",
-            "updated_at" => "2017-08-03 19:58:35",
-            "deleted_at" => null,
+            'id' => 297635,
+            'signup_id' => 4036823,
+            'campaign_id' => 7831,
+            'northstar_id' => '5564c93d469c6415048b8670',
+            'url' => 'https://s3.amazonaws.com/ds-rogue-prod/uploads/reportback-items/4036823-31b2064182a7fab7aa08d7e624faff0a-1501790315.jpeg',
+            'caption' => 'test',
+            'status' => 'pending',
+            'source' => 'phoenix-next',
+            'remote_addr' => '104.156.90.29',
+            'created_at' => '2017-08-03 19:58:35',
+            'updated_at' => '2017-08-03 19:58:35',
+            'deleted_at' => null,
         ];
 
         $blinkRestClient = new MockBlink($this->authorizedConfig, [

--- a/tests/BlinkTest.php
+++ b/tests/BlinkTest.php
@@ -48,7 +48,7 @@ class BlinkTest extends PHPUnit_Framework_TestCase
     /**
      * Test that we can notify blink of user campaign signup.
      */
-    public function testUserSigup()
+    public function testUserSigupCreate()
     {
         // Input data.
         $rogueSignupPayload = [
@@ -75,7 +75,7 @@ class BlinkTest extends PHPUnit_Framework_TestCase
     /**
      * Test that we can notify blink of user signup post (AKA campaign reporback).
      */
-    public function testUserSignupPost()
+    public function testUserSignupPostCreate()
     {
         // Input data.
         $rogueReportbackPayload = [

--- a/tests/BlinkTest.php
+++ b/tests/BlinkTest.php
@@ -71,4 +71,31 @@ class BlinkTest extends PHPUnit_Framework_TestCase
         $result = $blinkRestClient->userSignup($rogueSignupPayload);
         $this->assertTrue($result);
     }
+
+    /**
+     * Test that we can notify blink of user campaign reporback.
+     */
+    public function testUserReportback()
+    {
+        // Input data.
+        $rogueReportbackPayload = [
+            'id' => 4036838,
+            'northstar_id' => '598ca42c10707d7680749f81',
+            'campaign_id' => 7,
+            'campaign_run_id' => 7818,
+            'quantity' => 12,
+            'quantity_pending' => null,
+            'why_participated' => 'I love to test!',
+            'source' => 'niche',
+            'created_at' => '2017-08-10 18:21:35',
+            'updated_at' => '2017-08-10 18:21:35',
+        ];
+
+        $blinkRestClient = new MockBlink($this->authorizedConfig, [
+            new BlinkResponse,
+        ]);
+
+        $result = $blinkRestClient->userReporback($rogueReportbackPayload);
+        $this->assertTrue($result);
+    }
 }

--- a/tests/BlinkTest.php
+++ b/tests/BlinkTest.php
@@ -8,7 +8,7 @@ use DoSomething\GatewayTests\Helpers\UserResponse;
 class BlinkTest extends PHPUnit_Framework_TestCase
 {
     protected $authorizedConfig = [
-        'url' => 'https://blink-phpunit.dosomething.org', // not a real server!
+        'url' => 'https://blink-phpunit.dosomething.org/api/', // not a real server!
         'user' => 'blink',
         'password' => 'blink',
     ];

--- a/tests/BlinkTest.php
+++ b/tests/BlinkTest.php
@@ -27,9 +27,9 @@ class BlinkTest extends PHPUnit_Framework_TestCase
     ];
 
     /**
-     * Test that we can notify blink o user creation.
+     * Test that we can notify blink of user creation.
      */
-    public function testCreateSignup()
+    public function testUserCreate()
     {
         $blinkRestClient = new MockBlink($this->authorizedConfig, [
             new BlinkResponse,
@@ -42,6 +42,33 @@ class BlinkTest extends PHPUnit_Framework_TestCase
         $northstarUser = $northstarRestClient->getUser('email', 'kitty@xavierinstitute.edu');
 
         $result = $blinkRestClient->userCreate($northstarUser->toArray());
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test that we can notify blink of user campaign signup.
+     */
+    public function testUserSigup()
+    {
+        // Input data.
+        $rogueSignupPayload = [
+            'id' => 4036838,
+            'northstar_id' => '598ca42c10707d7680749f81',
+            'campaign_id' => 7,
+            'campaign_run_id' => 7818,
+            'quantity' => 12,
+            'quantity_pending' => null,
+            'why_participated' => 'I love to test!',
+            'source' => 'niche',
+            'created_at' => '2017-08-10 18:21:35',
+            'updated_at' => '2017-08-10 18:21:35',
+        ];
+
+        $blinkRestClient = new MockBlink($this->authorizedConfig, [
+            new BlinkResponse,
+        ]);
+
+        $result = $blinkRestClient->userSignup($rogueSignupPayload);
         $this->assertTrue($result);
     }
 }


### PR DESCRIPTION
#### What's this PR do?
Ths PR introduces basic API wrapper for [DoSomething/blink](https://github.com/DoSomething/blink).

The following event endpoints are supported:

```php
// POST https://blink.dosomething.org/api/v1/events/user-signup
// Creates user signup to a campaign.
$blinkRestClient->userSignup($rogueSignupPayload);

// POST https://blink.dosomething.org/api/v1/events/user-signup-post
// Creates user signup post (reportback) to a campaign.
$blinkRestClient->userSignupPost($rogueSignupPostPayload);
```

#### How should this be manually tested?
`./vendor/bin/phpunit`

#### Any background context you want to provide?
This is a part of Rogue -> Blink -> customer.io integration pipeline.

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested with blink staging
