### PR TITLE
Don't attempt to get token if nobody is logged-in.

### DIFF
--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -359,6 +359,12 @@ trait AuthorizesWithNorthstar
     protected function getAuthorizationHeader($forceRefresh = false)
     {
         $token = $this->getAccessToken();
+        $user = $this->getFrameworkBridge()->getCurrentUser();
+
+        // Don't attempt to refresh token if there isn't a logged-in user.
+        if ($this->grant === 'authorization_code' && ! $user) {
+            return [];
+        }
 
         // If the token is expired, fetch a new one before making the request.
         if (! $token || ($token && $token->hasExpired()) || $forceRefresh) {


### PR DESCRIPTION
#### Changes
This fixes an issue where we'd try to refresh the access token for a non-existent user if using the `authorization_code` grant and nobody was logged in. 🐛

[Pivotal #150234689](https://www.pivotaltracker.com/story/show/150234689)