### PR TITLE
Return the full response from gladiator

### DIFF
--- a/src/Gladiator.php
+++ b/src/Gladiator.php
@@ -75,7 +75,7 @@ class Gladiator extends RestApiClient
             'competition_id' => $competition_id,
         ]);
 
-        return $this->responseSuccessful($response);
+        return $response;
     }
 
     /**

--- a/tests/GladiatorTest.php
+++ b/tests/GladiatorTest.php
@@ -35,6 +35,6 @@ class GladiatorTest extends PHPUnit_Framework_TestCase
 
         $response = $restClient->unsubscribeUser('550200bba39awieg467a3cg2', '6749');
 
-        $this->assertResponseOk();
+        $this->assertArrayHasKey('message', $response);
     }
 }

--- a/tests/GladiatorTest.php
+++ b/tests/GladiatorTest.php
@@ -35,6 +35,6 @@ class GladiatorTest extends PHPUnit_Framework_TestCase
 
         $response = $restClient->unsubscribeUser('550200bba39awieg467a3cg2', '6749');
 
-        $this->assertTrue($response);
+        $this->assertResponseOk();
     }
 }


### PR DESCRIPTION
This updates the gladiator integration to return the full response from gladiator when a user tries to unsubscribe. This will allow gladiator to send over more detailed messages about what happened instead of just `true` or `false`

I need to do this so that we can be clear if a user unsubscribed, if they are already unsubscribed, or if there was an actual server error. 