### PR TITLE
Add key command for easy setup.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "guzzlehttp/guzzle": "^6.2.1",
     "league/oauth2-client": "~2.2",
     "symfony/psr-http-message-bridge": "^1.0",
-    "zendframework/zend-diactoros": "^1.3"
+    "zendframework/zend-diactoros": "^1.3",
+    "gree/jose": "^2.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",

--- a/src/Laravel/GatewayServiceProvider.php
+++ b/src/Laravel/GatewayServiceProvider.php
@@ -21,8 +21,15 @@ class GatewayServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        // Allow sample migrations to be published using `php artisan vendor:publish`.
-        $this->publishes([realpath(__DIR__ . '/Migrations/') => database_path('migrations')], 'migrations');
+        if ($this->app->runningInConsole()) {
+            // Allow sample migrations to be published using `php artisan vendor:publish`.
+            $this->publishes([realpath(__DIR__ . '/Migrations/') => database_path('migrations')], 'migrations');
+
+            // Register 'key' Artisan command.
+            $this->commands([
+                \DoSomething\Gateway\Server\Commands\PublicKeyCommand::class,
+            ]);
+        }
     }
 
     /**

--- a/src/Server/Commands/PublicKeyCommand.php
+++ b/src/Server/Commands/PublicKeyCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DoSomething\Gateway\Server\Commands;
+
+use JOSE_JWK;
+use Illuminate\Console\Command;
+use DoSomething\Gateway\Common\RestApiClient;
+
+class PublicKeyCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'gateway:key';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Load public key for Gateway server middleware.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $url = config('services.northstar.url');
+        $path = config('services.northstar.key');
+        $http = new RestApiClient($url);
+
+        // Print an error if a URL isn't set in config file.
+        if (empty($url)) {
+            $this->error('Set a Northstar URL in config/services.php! <https://git.io/...>');
+        }
+
+        $discoveryUrl = $url.'/.well-known/openid-configuration';
+
+        $this->comment('Reading configuration from '.$discoveryUrl.'...');
+        $configuration = $http->get($discoveryUrl);
+        $jwksUri = $configuration['jwks_uri'];
+
+        $this->comment('Reading public key from '.$jwksUri.'...');
+        $jwks = $http->get($jwksUri);
+
+        $components = $jwks['keys'][0];
+        $jwk = JOSE_JWK::decode($components);
+
+        file_put_contents($path, (string) $jwk);
+        $this->info('Wrote public key to ' . $path . '.');
+    }
+}

--- a/src/Server/Commands/PublicKeyCommand.php
+++ b/src/Server/Commands/PublicKeyCommand.php
@@ -36,16 +36,29 @@ class PublicKeyCommand extends Command
         // Print an error if a URL isn't set in config file.
         if (empty($url)) {
             $this->error('Set a Northstar URL in config/services.php! <https://git.io/...>');
+
+            return false;
         }
 
         $discoveryUrl = $url.'/.well-known/openid-configuration';
 
         $this->comment('Reading configuration from '.$discoveryUrl.'...');
         $configuration = $http->get($discoveryUrl);
+        if (empty($configuration)) {
+            $this->error('Could not load configuration.');
+
+            return false;
+        }
+
         $jwksUri = $configuration['jwks_uri'];
 
         $this->comment('Reading public key from '.$jwksUri.'...');
         $jwks = $http->get($jwksUri);
+        if (empty($jwks)) {
+            $this->error('Could not load public key.');
+
+            return false;
+        }
 
         $components = $jwks['keys'][0];
         $jwk = JOSE_JWK::decode($components);


### PR DESCRIPTION
### Changes
This pull request adds a `gateway:key` command which loads Northstar's public key automatically using it's new [discovery & key endpoints](https://github.com/DoSomething/northstar/pull/655). This makes server setup a bit easier, but is especially handy for setting up local environments (rather than instructing people to visit Aurora & copy a big blob of text).

References [#151957763](https://www.pivotaltracker.com/story/show/151957763).