### PR TITLE
Fixes for using a provided token with requests.

### DIFF
--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -9,6 +9,7 @@ use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use DoSomething\Gateway\Server\Token;
 
 trait AuthorizesWithNorthstar
 {
@@ -284,13 +285,16 @@ trait AuthorizesWithNorthstar
      * Make request using the provided access token (for example, to make
      * a request to another service in order to complete an API request).
      *
-     * @param AccessToken $token
+     * @param Token $token
      * @return $this
      */
-    public function withToken(AccessToken $token)
+    public function withToken(Token $token)
     {
         $this->grant = 'provided_token';
-        $this->token = $token;
+        $this->token = new AccessToken([
+            'access_token' => $token->jwt(),
+            'expires' => $token->expires()->timestamp,
+        ]);
 
         return $this;
     }

--- a/src/AuthorizesWithNorthstar.php
+++ b/src/AuthorizesWithNorthstar.php
@@ -373,15 +373,20 @@ trait AuthorizesWithNorthstar
      * Overrides this empty method in RestApiClient.
      *
      * @param bool $forceRefresh - Should the token be refreshed, even if expiration timestamp hasn't passed?
-     * @return null|string
+     * @return array
      * @throws \Exception
      */
     protected function getAuthorizationHeader($forceRefresh = false)
     {
         $token = $this->getAccessToken();
-        $user = $this->getFrameworkBridge()->getCurrentUser();
+
+        // If we're using a token provided with the request, return it.
+        if ($this->grant === 'provided_token') {
+            return ['Authorization' => 'Bearer ' . $token->getToken()];
+        }
 
         // Don't attempt to refresh token if there isn't a logged-in user.
+        $user = $this->getFrameworkBridge()->getCurrentUser();
         if ($this->grant === 'authorization_code' && ! $user) {
             return [];
         }

--- a/src/Laravel/LaravelNorthstar.php
+++ b/src/Laravel/LaravelNorthstar.php
@@ -4,7 +4,9 @@ namespace DoSomething\Gateway\Laravel;
 
 use DoSomething\Gateway\Northstar;
 use DoSomething\Gateway\Exceptions\InternalException;
+use DoSomething\Gateway\Exceptions\ForbiddenException;
 use DoSomething\Gateway\Exceptions\ValidationException;
+use DoSomething\Gateway\Exceptions\UnauthorizedException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Validation\ValidationException as LaravelValidationException;
 
@@ -42,6 +44,10 @@ class LaravelNorthstar extends Northstar
             return parent::send($method, $path, $options, $withAuthorization);
         } catch (ValidationException $e) {
             throw LaravelValidationException::withMessages($e->getErrors());
+        } catch (UnauthorizedException $e) {
+            throw new \Illuminate\Auth\AuthenticationException;
+        } catch (ForbiddenException $e) {
+            throw new \Illuminate\Auth\AuthenticationException;
         } catch (InternalException $e) {
             $message = 'Northstar returned an unexpected error for that request.';
 


### PR DESCRIPTION
This just fixes a few issues when using Gateway to forward along requests to another service:

💥 Fixes an issue where we couldn't return a `Authorization` header for provided token. d0f9801

🚸 Converts Gateway's auth exceptions to equivalent Laravel ones for `LaravelNorthstar` 723334e

🎟 Allows passing a plain ol' Gateway token instance to the `withToken` method, rather than having to build a `League\OAuth2\Client\Token\AccessToken` by hand each time:

```diff
- gateway('northstar')->withToken(new AccessToken([
-     'access_token' => token()->jwt(),
-     'expires' => token()->expires()->timestamp,
- ])->getAllUsers();
+ gateway('northstar')->withToken(token())->getAllUsers();
```