### PR TITLE
changing json_decode error to return array

### DIFF
--- a/src/Common/RestApiClient.php
+++ b/src/Common/RestApiClient.php
@@ -211,7 +211,7 @@ class RestApiClient
             return json_decode($response->getBody()->getContents(), true);
         } catch (\GuzzleHttp\Exception\ClientException $e) {
             $endpoint = strtoupper($method).' '.$path;
-            $response = json_decode($e->getResponse()->getBody()->getContents());
+            $response = json_decode($e->getResponse()->getBody()->getContents(), true);
 
             switch ($e->getCode()) {
                 // If the request is bad, throw a generic bad request exception.
@@ -233,7 +233,7 @@ class RestApiClient
                 // If it's a validation error, throw a generic validation error.
                 case 422:
                     // TODO: don't require error fields
-                    $errors = $response->error->fields;
+                    $errors = $response['error']['fields'];
                     throw new ValidationException($errors, $endpoint);
 
                 default:


### PR DESCRIPTION
### What's this do?:
- has the `json_decode` method return an array for the errors. Fixing an issue where we pass an object to the Laravel Validation error constructor and it complains.