### PR TITLE
Always include default headers

### DIFF
--- a/src/Common/RestApiClient.php
+++ b/src/Common/RestApiClient.php
@@ -258,7 +258,8 @@ class RestApiClient
         $traits = Introspector::getAllClassTraits($class);
 
         if (empty($options['headers'])) {
-            $options['headers'] = [];
+            // Guzzle doesn't merge default headers with $options array
+            $options['headers'] = $this->defaultHeaders;
         }
 
         // If these traits have a "hook" (uh oh!), run that before making a request.


### PR DESCRIPTION
[Slack chatter](https://dosomething.slack.com/archives/C0YGXUE01/p1508789568000390)

Guzzle doesn't merge default headers with `$options` array, so a lot of times we are losing the default headers in our request. We want to make sure to always include those to get the expected response.