### PR TITLE
creating a more sensical query param for "pretend"

### DIFF
--- a/src/Northstar.php
+++ b/src/Northstar.php
@@ -117,7 +117,9 @@ class Northstar extends RestApiClient
      */
     public function mergeUsers($id, $duplicateId, $pretend = false)
     {
-        $response = $this->post('v1/users/'.$id.'/merge/?pretend='.$pretend, ['id' => $duplicateId]);
+        $pretendParam = $pretend ? 'pretend=true' : null;
+
+        $response = $this->post('v1/users/'.$id.'/merge/?'.$pretendParam, ['id' => $duplicateId]);
 
         return new NorthstarUser($response['data']);
     }

--- a/src/Northstar.php
+++ b/src/Northstar.php
@@ -117,9 +117,9 @@ class Northstar extends RestApiClient
      */
     public function mergeUsers($id, $duplicateId, $pretend = false)
     {
-        $pretendParam = $pretend ? 'pretend=true' : null;
+        $pretendParam = $pretend ? '?pretend=true' : null;
 
-        $response = $this->post('v1/users/'.$id.'/merge/?'.$pretendParam, ['id' => $duplicateId]);
+        $response = $this->post('v1/users/'.$id.'/merge'.$pretendParam, ['id' => $duplicateId]);
 
         return new NorthstarUser($response['data']);
     }


### PR DESCRIPTION
Northstar's merge action is just checking for an existing`pretend` param value, hence before this, when we were just appending a '1' to the pretend param (when the `$pretend` argument was `true`), it was still registering as a pretend merge, and when the arg was `false` it wouldn't append anything and the url would be `.../merge?pretend=` and it would merge for real on the backend.

This just makes things more sensical, and when the `$pretend` arg is `false`, it won't add that query param to begin with, and when `true`, it'll actually be `pretend=true`.