### PR TITLE
Add 'SetGuard' middleware.

### DIFF
--- a/docs/traits/AuthorizesWithOAuth2.md
+++ b/docs/traits/AuthorizesWithOAuth2.md
@@ -36,7 +36,7 @@ class ExampleClient extends RestApiClient
 }
 ```
 
-Now, any requests where the `$withAuthorization` argument is `true` will use the configured `default_grant` to fetch an access token. You can always switch grants using the `asClient` or `asUser` methods, or provide a JWT Token using the `withToken` method alongside the [`token` helper]().
+Now, any requests where the `$withAuthorization` argument is `true` will use the configured `default_grant` to fetch an access token. You can always switch grants using the `asClient` or `asUser` methods, or provide a JWT Token using the `withToken` method alongside the [`token` helper](../server/ResourceServer.md#usage).
 
 ```php
 <?php

--- a/src/Server/Middleware/SetGuard.php
+++ b/src/Server/Middleware/SetGuard.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DoSomething\Gateway\Server\Middleware;
+
+use Closure;
+
+class SetGuard
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string    $guard
+     * @return mixed
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function handle($request, Closure $next, $guard)
+    {
+        // Set the preferred guard for this request.
+        auth()->shouldUse($guard);
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
### What's this PR do?
This pull request adds the `SetGuard` middleware referenced in the [server installation guide](https://github.com/DoSomething/gateway/blob/docz/docs/server/ResourceServer.md#installation). This is just a simple middleware extracted from Rogue which sets the default guard, which we use to force the OAuth guard/provider to be used on `v3` routes. (Otherwise it would still use the default `web` guard unless someone applied the `auth:api` middleware!)

### How should this be reviewed?
🎯

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?