### PR TITLE
Update OAuth exceptions to be more clear.

### DIFF
--- a/src/Server/Exceptions/AccessDeniedException.php
+++ b/src/Server/Exceptions/AccessDeniedException.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace DoSomething\Gateway\Server\Exceptions;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+class AccessDeniedException extends Exception
+{
+    /**
+     * Create a new "access denied" exception.
+     *
+     * @return void
+     */
+    public function __construct($message, $hint = null)
+    {
+        $this->message = $message;
+        $this->hint = $hint;
+
+        parent::__construct($message);
+    }
+
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request)
+    {
+        $contents = [
+            'error' => 'access_denied',
+            'message' => $this->message,
+        ];
+
+        if ($this->hint) {
+            $contents['hint'] = $this->hint;
+        }
+
+        // Return a properly formatted error according
+        // to RFC 6749, Section 5.2. <goo.gl/EeUqjz>
+        return new JsonResponse($contents, 401, [
+            'WWW-Authenticate' => 'Bearer realm="OAuth"',
+        ]);
+    }
+}

--- a/tests/Server/TokenTest.php
+++ b/tests/Server/TokenTest.php
@@ -2,7 +2,7 @@
 
 use Carbon\Carbon;
 use DoSomething\Gateway\Server\Token;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use DoSomething\Gateway\Server\Exceptions\AccessDeniedException;
 
 class TokenTest extends TestCase
 {
@@ -21,7 +21,7 @@ class TokenTest extends TestCase
         $request = $this->createRequest('Bearer nah');
         $token = new Token($request, $this->key);
 
-        $this->setExpectedException(AccessDeniedHttpException::class);
+        $this->setExpectedException(AccessDeniedException::class);
         $token->exists(); // throws!
     }
 
@@ -33,7 +33,7 @@ class TokenTest extends TestCase
         $this->mockTime('9/14/2017 7:00pm');
         $token = new Token($request, $this->key);
 
-        $this->setExpectedException(AccessDeniedHttpException::class);
+        $this->setExpectedException(AccessDeniedException::class);
         $token->exists(); // throws!
     }
 
@@ -46,7 +46,7 @@ class TokenTest extends TestCase
         $this->mockTime('9/14/2017 4:10pm');
         $token = new Token($request, $this->key);
 
-        $this->setExpectedException(AccessDeniedHttpException::class);
+        $this->setExpectedException(AccessDeniedException::class);
         $token->exists(); // throws!
     }
 


### PR DESCRIPTION
### What's this PR do?
This pull request update's Gateway's included OAuth exceptions to be more clear – they have more helpful error messages, powered by [Laravel 5.5 renderable exceptions](https://laravel.com/docs/5.5/errors#renderable-exceptions) & the correct `401` status code, ensuring spec-compliant OAuth clients work out of the box!

### How should this be reviewed?
I've tested this alongside my local Rogue, and updated the corresponding unit tests.

### Checklist
- [x] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?