### PR TITLE
adds asUser() when refreshing expired token

### DIFF
--- a/src/Laravel/Middleware/RefreshTokenMiddleware.php
+++ b/src/Laravel/Middleware/RefreshTokenMiddleware.php
@@ -34,7 +34,7 @@ class RefreshTokenMiddleware
     public function handle($request, Closure $next)
     {
         // If a user is logged in with an expired access token, try to refresh it.
-        $this->northstar->refreshIfExpired();
+        $this->northstar->asUser()->refreshIfExpired();
 
         return $next($request);
     }


### PR DESCRIPTION
### What's this PR do?
Refreshes token as user when refreshing expired token. 

### How should this be reviewed?
👀 

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
