### PR TITLE
Don't register clients as singletons & enable package discovery.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,12 @@
     "psr-4": {
       "DoSomething\\GatewayTests\\": "tests/"
     }
+  },
+  "extra": {
+    "laravel": {
+        "providers": [
+            "DoSomething\\Gateway\\Laravel\\GatewayServiceProvider"
+        ]
+    }
   }
 }

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -10,22 +10,14 @@ Then, follow the instructions for [Laravel](#Laravel) or [vanilla PHP](#Vanilla-
 
 ### Laravel
 
-Laravel support is built-in. First, add the service provider to your `config/app.php`:
+Laravel will automatically register Gateway's service provider with [package discovery](https://laravel.com/docs/5.5/packages#package-discovery).
 
-```php
-'providers' => [
-    // ...
-    DoSomething\Gateway\Laravel\GatewayServiceProvider::class,
-],
-```
-
-Then, configure the services you're using in `config/services.php`:
+You can configure the services you're using in `config/services.php`:
 
 ```php
 'northstar' => [
     'grant' => 'client_credentials', // Default OAuth grant to use: either 'authorization_code' or 'client_credentials'
     'url' => 'https://northstar.dosomething.org', // the environment you want to connect to
-    'key' => storage_path('keys/public.key'), // optional: used for Gateway server middleware
 
     // Then, configure client ID, client secret, and scopes per grant.
     'client_credentials' => [

--- a/src/Laravel/GatewayServiceProvider.php
+++ b/src/Laravel/GatewayServiceProvider.php
@@ -39,15 +39,15 @@ class GatewayServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(Northstar::class, function () {
+        $this->app->bind(Northstar::class, function () {
             return new LaravelNorthstar(config('services.northstar'));
         });
 
-        $this->app->singleton(Blink::class, function () {
+        $this->app->bind(Blink::class, function () {
             return new Blink(config('services.blink'));
         });
 
-        $this->app->singleton(Gladiator::class, function () {
+        $this->app->bind(Gladiator::class, function () {
             return new Gladiator(config('services.gladiator'));
         });
 


### PR DESCRIPTION
### What's this PR do?
Two changes:

🔂 Gateway will no longer register clients as singletons, which means we can't accidentally leak details between different parts of an application. Fixes #103.

🔍 Enables Laravel's [package discovery](https://laravel.com/docs/5.5/packages#package-discovery) for one less setup step!

### How should this be reviewed?
👀

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?