### PR TITLE
Experimental: Automatically configure Gateway mocks.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "league/oauth2-client": "~2.2",
     "symfony/psr-http-message-bridge": "^1.0",
     "zendframework/zend-diactoros": "^1.3",
-    "gree/jose": "^2.2"
+    "gree/jose": "^2.2",
+    "fzaninotto/faker": "^1.7"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",

--- a/src/Testing/WithGatewayMocks.php
+++ b/src/Testing/WithGatewayMocks.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace DoSomething\Gateway\Testing;
+
+use Mockery;
+use DoSomething\Gateway\Northstar;
+use DoSomething\Gateway\Resources\NorthstarUser;
+use DoSomething\Gateway\Laravel\LaravelNorthstar;
+
+/**
+ * @mixin \Illuminate\Foundation\Testing\TestCase
+ */
+trait WithGatewayMocks
+{
+    /**
+     * Create a fake Northstar user.
+     */
+    protected function makeNorthstarUser($attributes)
+    {
+        $faker = \Faker\Factory::create();
+
+        // Always return the same data based on the requested ID:
+        $indexes = array_only($attributes, ['id', 'email', 'mobile', '_id']);
+        $key = array_first(array_keys($indexes));
+        $faker->seed($indexes[$key]);
+
+        // Generate a fake ObjectID in case we need one.
+        $time = $faker->dateTimeBetween('1/1/2015', '1/1/2018')->getTimestamp();
+        $prefix = str_pad(dechex($time), 8, '0', STR_PAD_LEFT);
+        $random = substr($faker->sha256, 0, 16);
+        $objectId = $prefix . $random;
+
+        // Return a fake user based on the given ID:
+        return new NorthstarUser(array_merge([
+            'id' => $objectId,
+            'first_name' => $faker->firstName,
+            'last_name' => $faker->lastName,
+        ], $attributes));
+    }
+
+    /**
+     * Configure mocks for Northstar resources.
+     */
+    protected function configureNorthstarMock()
+    {
+        $this->app->singleton(Northstar::class, function () {
+            $mock = Mockery::mock(LaravelNorthstar::class, config('services.northstar'));
+            $mock->makePartial();
+
+            $mock->shouldReceive('getUser')->andReturnUsing(function ($type, $id) {
+                return $this->makeNorthstarUser([$type => $id]);
+            });
+
+            return $mock;
+        });
+    }
+}

--- a/tests/Testing/WithGatewayMocksTest.php
+++ b/tests/Testing/WithGatewayMocksTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use DoSomething\Gateway\Testing\WithGatewayMocks;
+
+class WithGatewayMocksTest extends TestCase
+{
+    use WithGatewayMocks;
+
+    /** @test */
+    public function testMakeNorthstarUserWithId()
+    {
+        $user = $this->makeNorthstarUser(['id' => '5543dfd6469c64ec7d8b46b3']);
+
+        // The generated user should be consistent across test runs:
+        $this->assertEquals('5543dfd6469c64ec7d8b46b3', $user->id);
+        $this->assertEquals('Zoie', $user->first_name);
+        $this->assertEquals('Koepp', $user->last_name);
+    }
+
+    /** @test */
+    public function testMakeNorthstarUserWithEmail()
+    {
+        $user = $this->makeNorthstarUser(['email' => 'test@example.com']);
+
+        // The generated user should be consistent across test runs:
+        $this->assertEquals('572d2180adec364795d42f36', $user->id);
+        $this->assertEquals('Brandyn', $user->first_name);
+        $this->assertEquals('Mitchell', $user->last_name);
+    }
+}


### PR DESCRIPTION
### What's this PR do?
Okay - this is a kinda wild idea, but I'm pretty excited about it. We spend a fair amount of time in test suites mocking out external API calls by setting per-test mocks (when I ask for this thing, give me this instead). What if we instead swapped out the _entire_ client with a mocked version?

This pull request introduces a `WithGatewayMocks` trait for PHPUnit that configures a mock version of the Northstar client, and automatically returns fake data for any calls to `getUser`. We seed the Faker instance based on the request, so while it's "random" data it's still completely deterministic!

For example, no matter how many times I ask for a user with ID `5543dfd6469c64ec7d8b46b3` it'll _always_ be named "Zoe Koepp". This would make it dead-simple for an application like Rogue to mock out a ton of Northstar requests without any manual configuration.

### How should this be reviewed?
This is just a proof-of-concept. If others are excited about this, I'll put some more time into it to get an MVP that we can actually merge in and start using.

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
