### PR TITLE
Don't force 'application/json' content type.

### DIFF
--- a/src/Common/RestApiClient.php
+++ b/src/Common/RestApiClient.php
@@ -42,7 +42,6 @@ class RestApiClient
     public function __construct($url, $overrides = [])
     {
         $this->defaultHeaders = [
-            'Content-Type' => 'application/json',
             'Accept' => 'application/json',
         ];
 


### PR DESCRIPTION
### What's this PR do?
If we want to make non-JSON requests (e.g. `multipart/form-data` or XML or whatever), we can't! Guzzle should set this automatically when we're using `json` option, so this is redundant.

### How should this be reviewed?
👀

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
