### PR TITLE
Fix typo in default `handleValidationException`.

### DIFF
--- a/src/Common/RestApiClient.php
+++ b/src/Common/RestApiClient.php
@@ -209,7 +209,7 @@ class RestApiClient
     public function handleValidationException($endpoint, $response, $method, $path, $options)
     {
         $errors = $response['error']['fields'];
-        throw new ValidationException($response, $endpoint);
+        throw new ValidationException($errors, $endpoint);
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?
This fixes a typo introduced in 6cbb62ecb928b159c4f63f6f016461fa291fe15e.

### How should this be reviewed?
We should be sending _just_ the errors to the exception now, not the whole JSON response.

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
