### PR TITLE
Adds activity scope to withAccessToken

### DIFF
--- a/src/Testing/WithOAuthTokens.php
+++ b/src/Testing/WithOAuthTokens.php
@@ -51,7 +51,7 @@ trait WithOAuthTokens
      * @param array $scopes
      * @return $this
      */
-    public function withAccessToken($userId, $role = 'user', $scopes = ['user', 'role:staff', 'role:admin'])
+    public function withAccessToken($userId, $role = 'user', $scopes = ['user', 'role:staff', 'role:admin', 'activity'])
     {
         $privateKey = dirname(__FILE__) . '/example-private.key';
         $jti = hash('sha256', mt_rand());


### PR DESCRIPTION
### What's this PR do?
Adds `activity` scope to `withAccessToken` function now that Rogue requires this in [this PR](https://github.com/DoSomething/rogue/pull/644).

### How should this be reviewed?
👀 

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
