### PR TITLE
Adds write scope to withAccessToken 

### DIFF
--- a/src/Testing/WithOAuthTokens.php
+++ b/src/Testing/WithOAuthTokens.php
@@ -51,7 +51,7 @@ trait WithOAuthTokens
      * @param array $scopes
      * @return $this
      */
-    public function withAccessToken($userId, $role = 'user', $scopes = ['user', 'role:staff', 'role:admin', 'activity'])
+    public function withAccessToken($userId, $role = 'user', $scopes = ['user', 'role:staff', 'role:admin', 'activity', 'write'])
     {
         $privateKey = dirname(__FILE__) . '/example-private.key';
         $jti = hash('sha256', mt_rand());


### PR DESCRIPTION
### What's this PR do?
Adds `write` scope to [`withAccessToken`](https://github.com/DoSomething/gateway/blob/master/src/Testing/WithOAuthTokens.php#L54) now that Rogue also requires this for create, update, and delete endpoints.

### How should this be reviewed?
👀 

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
