### PR TITLE
only check scopes if a token exists

### DIFF
--- a/src/Server/Middleware/RequireScope.php
+++ b/src/Server/Middleware/RequireScope.php
@@ -35,6 +35,10 @@ class RequireScope
      */
     public function handle($request, Closure $next, ...$requestedScopes)
     {
+        if (! $this->token->exists()) {
+            return $next($request);
+        }
+
         $providedScopes = $this->token->scopes;
 
         // If any of the requested scopes were not provided, throw an exception.

--- a/tests/Server/Middleware/RequireScopeTest.php
+++ b/tests/Server/Middleware/RequireScopeTest.php
@@ -10,12 +10,19 @@ class RequireScopeTest extends TestCase
     /** @test */
     public function testNoToken()
     {
+        // We can use $next & $passed as a spy here.
+        $passed = false;
+        $next = function () use (&$passed) {
+            $passed = true;
+        };
+
         $request = $this->createRequest(null);
 
         $middleware = new RequireScope(new Token($request, $this->key));
-        $middleware->handle($request, function () {
-            // ...
-        }, 'user');
+        $middleware->handle($request, $next, 'user');
+
+        // Since we don't have a token on the request, this should still pass!
+        $this->assertTrue($passed);
     }
 
     /** @test */

--- a/tests/Server/Middleware/RequireScopeTest.php
+++ b/tests/Server/Middleware/RequireScopeTest.php
@@ -10,8 +10,6 @@ class RequireScopeTest extends TestCase
     /** @test */
     public function testNoToken()
     {
-        $this->setExpectedException(AccessDeniedHttpException::class);
-
         $request = $this->createRequest(null);
 
         $middleware = new RequireScope(new Token($request, $this->key));


### PR DESCRIPTION
### What's this PR do?
Updates code to only check scope if a token exists. 

We want anonymous requests to access data i.e. to see the gallery of posts before they signup for a campaign! 

### How should this be reviewed?
👀 

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
