### PR TITLE
Tell Laravel's guard about updated access token.

### DIFF
--- a/src/Laravel/LaravelOAuthBridge.php
+++ b/src/Laravel/LaravelOAuthBridge.php
@@ -80,8 +80,14 @@ class LaravelOAuthBridge implements OAuthBridgeContract
 
         // And then update their token details.
         $user->setOAuthToken($token);
-
         $user->save();
+
+        // Finally, tell the guard about the new token if this is the currently
+        // logged-in user. (Otherwise, they wouldn't get the new token until
+        // the following page load.)
+        if (auth()->user() && auth()->user()->getNorthstarIdentifier() === $northstarId) {
+            auth()->setUser($user);
+        }
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?
Laravel's guard [keeps a `$user` instance cached](https://github.com/laravel/framework/blob/3f4bb53dcd176fad6c9de342c1b632c9ed05f75d/src/Illuminate/Auth/SessionGuard.php#L119-L124) so that multiple requests to `Auth::user()` don't hit the database each time. This means that we won't see any changes made to that user record until the following page load, however, unless we tell the user provider about it!

This pull request updates that cached user with [`Auth::setUser`](https://github.com/laravel/framework/blob/3f4bb53dcd176fad6c9de342c1b632c9ed05f75d/src/Illuminate/Auth/SessionGuard.php#L735-L750) so that if we update a user's access token via [the "refresh token" middleware](https://github.com/DoSomething/gateway/blob/master/src/Laravel/Middleware/RefreshTokenMiddleware.php), we'll get that new one [on future calls to `Auth::user()`](https://github.com/DoSomething/phoenix-next/blob/14d432285bb9d6ce9e8a54d45cc79f65ccb98e85/app/Providers/AppServiceProvider.php#L55-L63).

### How should this be reviewed?
I'll put up a PR to update Phoenix's dependencies after this is merged!

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?