### PR TITLE
Adds logout function to Gateway guard so we can make multiple API requests with different tokens in unit tests. 

### DIFF
--- a/src/Laravel/GatewayServiceProvider.php
+++ b/src/Laravel/GatewayServiceProvider.php
@@ -69,7 +69,7 @@ class GatewayServiceProvider extends ServiceProvider
         $this->app->alias(Northstar::class, 'northstar');
 
         // Register token validator w/ config dependency.
-        $this->app->singleton(Token::class, function ($app) {
+        $this->app->bind(Token::class, function ($app) {
             $key = config('auth.providers.northstar.key');
 
             // If not set, check old suggested config location:
@@ -77,14 +77,14 @@ class GatewayServiceProvider extends ServiceProvider
                 $key = config('services.northstar.key');
             }
 
-            return new Token($app[Request::class], $key);
+            return new Token($key);
         });
 
         // Register custom Gateway authentication guard.
         Auth::extend('gateway', function ($app, $name, array $config) {
             $provider = Auth::createUserProvider($config['provider']);
 
-            return new GatewayGuard($app[Token::class], $provider, $app[Request::class]);
+            return new GatewayGuard($provider, $app[Request::class]);
         });
 
         // Register custom Gateway user provider.

--- a/src/Laravel/GatewayServiceProvider.php
+++ b/src/Laravel/GatewayServiceProvider.php
@@ -11,6 +11,7 @@ use DoSomething\Gateway\Server\Token;
 use Illuminate\Support\ServiceProvider;
 use DoSomething\Gateway\Server\GatewayGuard;
 use DoSomething\Gateway\Server\GatewayUserProvider;
+use DoSomething\Gateway\Server\LaravelRequestHandler;
 
 class GatewayServiceProvider extends ServiceProvider
 {
@@ -77,7 +78,7 @@ class GatewayServiceProvider extends ServiceProvider
                 $key = config('services.northstar.key');
             }
 
-            return new Token($key);
+            return new Token(new LaravelRequestHandler(), $key);
         });
 
         // Register custom Gateway authentication guard.

--- a/src/Server/GatewayGuard.php
+++ b/src/Server/GatewayGuard.php
@@ -18,22 +18,14 @@ class GatewayGuard implements Guard
     protected $user;
 
     /**
-     * The validated JWT token.
-     *
-     * @var Token
-     */
-    protected $token;
-
-    /**
      * Create a new authentication guard.
      *
      * @param  Token  $token
      * @param  UserProvider  $provider
      * @param  Request  $request
      */
-    public function __construct(Token $token, UserProvider $provider, Request $request)
+    public function __construct(UserProvider $provider, Request $request)
     {
-        $this->token = $token;
         $this->provider = $provider;
         $this->request = $request;
     }
@@ -97,7 +89,7 @@ class GatewayGuard implements Guard
      */
     public function id()
     {
-        return $this->token->id;
+        return app(Token::class)->id;
     }
 
     /**

--- a/src/Server/GatewayGuard.php
+++ b/src/Server/GatewayGuard.php
@@ -136,10 +136,9 @@ class GatewayGuard implements Guard
     /**
      * Log the user out.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable $user
      * @return $this
      */
-    public function logout(Authenticatable $user)
+    public function logout()
     {
         $this->user = null;
 

--- a/src/Server/GatewayGuard.php
+++ b/src/Server/GatewayGuard.php
@@ -132,4 +132,17 @@ class GatewayGuard implements Guard
 
         return $this;
     }
+
+    /**
+     * Log the user out.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable $user
+     * @return $this
+     */
+    public function logout(Authenticatable $user)
+    {
+        $this->user = null;
+
+        return $this;
+    }
 }

--- a/src/Server/LaravelRequestHandler.php
+++ b/src/Server/LaravelRequestHandler.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DoSomething\Gateway\Server;
+
+class LaravelRequestHandler implements RequestHandlerContract
+{
+    /**
+     * Return the current web request.
+     */
+    public function getRequest()
+    {
+        return request();
+    }
+}

--- a/src/Server/Middleware/RequireRole.php
+++ b/src/Server/Middleware/RequireRole.php
@@ -20,9 +20,8 @@ class RequireRole
      *
      * @param Token $token
      */
-    public function __construct(Token $token)
+    public function __construct()
     {
-        $this->token = $token;
     }
 
     /**
@@ -35,11 +34,11 @@ class RequireRole
      */
     public function handle($request, Closure $next, ...$allowedRoles)
     {
-        $role = $this->token->role;
+        $role = app(Token::class)->role;
 
         // Allow the 'admin' scope to grant privileges to clients.
         // @TODO: Remove this after refactoring client_credential tokens.
-        if (in_array('admin', $this->token->scopes)) {
+        if (in_array('admin', app(Token::class)->scopes)) {
             $role = 'admin';
         }
 

--- a/src/Server/Middleware/RequireRole.php
+++ b/src/Server/Middleware/RequireRole.php
@@ -20,8 +20,9 @@ class RequireRole
      *
      * @param Token $token
      */
-    public function __construct()
+    public function __construct(Token $token)
     {
+        $this->token = $token;
     }
 
     /**
@@ -34,11 +35,11 @@ class RequireRole
      */
     public function handle($request, Closure $next, ...$allowedRoles)
     {
-        $role = app(Token::class)->role;
+        $role = $this->token->role;
 
         // Allow the 'admin' scope to grant privileges to clients.
         // @TODO: Remove this after refactoring client_credential tokens.
-        if (in_array('admin', app(Token::class)->scopes)) {
+        if (in_array('admin', $this->token->scopes)) {
             $role = 'admin';
         }
 

--- a/src/Server/Middleware/RequireRole.php
+++ b/src/Server/Middleware/RequireRole.php
@@ -9,6 +9,23 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 class RequireRole
 {
     /**
+     * The JWT token.
+     *
+     * @var Token
+     */
+    protected $token;
+
+    /**
+     * RequireScope constructor.
+     *
+     * @param Token $token
+     */
+    public function __construct(Token $token)
+    {
+        $this->token = $token;
+    }
+
+    /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request $request
@@ -18,11 +35,11 @@ class RequireRole
      */
     public function handle($request, Closure $next, ...$allowedRoles)
     {
-        $role = token()->role;
+        $role = $this->token->role;
 
         // Allow the 'admin' scope to grant privileges to clients.
         // @TODO: Remove this after refactoring client_credential tokens.
-        if (in_array('admin', token()->scopes)) {
+        if (in_array('admin', $this->token->scopes)) {
             $role = 'admin';
         }
 

--- a/src/Server/Middleware/RequireRole.php
+++ b/src/Server/Middleware/RequireRole.php
@@ -16,7 +16,7 @@ class RequireRole
     protected $token;
 
     /**
-     * RequireScope constructor.
+     * RequireRole constructor.
      *
      * @param Token $token
      */

--- a/src/Server/RequestHandlerContract.php
+++ b/src/Server/RequestHandlerContract.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace DoSomething\Gateway\Server;
+
+interface RequestHandlerContract
+{
+    /**
+     * Return the current web request.
+     */
+    public function getRequest();
+}

--- a/src/Server/Token.php
+++ b/src/Server/Token.php
@@ -32,20 +32,12 @@ class Token
     protected $publicKey;
 
     /**
-     * The parsed and validated access token.
-     *
-     * @var \Lcobucci\JWT\Token
-     */
-    protected $token;
-
-    /**
      * Create a TokenValidator.
      *
      * @param $publicKey
      */
-    public function __construct($request, $publicKey)
+    public function __construct($publicKey)
     {
-        $this->request = $request;
         $this->publicKey = $publicKey;
     }
 
@@ -56,11 +48,7 @@ class Token
      */
     public function exists()
     {
-        if (! $this->token) {
-            $this->token = $this->parseToken();
-        }
-
-        return ! empty($this->token);
+        return ! empty($this->parseToken());
     }
 
     /**
@@ -126,11 +114,10 @@ class Token
      */
     public function jwt()
     {
-        if (! $this->token) {
-            $this->token = $this->parseToken();
-        }
 
-        return $this->token ? (string) $this->token : null;
+        $token = $this->parseToken();
+
+        return $token ? (string) $token : null;
     }
 
     /**
@@ -140,11 +127,9 @@ class Token
      */
     protected function getClaim($claim)
     {
-        if (! $this->token) {
-            $this->token = $this->parseToken();
-        }
+        $token = $this->parseToken();
 
-        return $this->token ? $this->token->getClaim($claim) : null;
+        return $token ? $token->getClaim($claim) : null;
     }
 
     /**
@@ -155,13 +140,13 @@ class Token
      */
     protected function parseToken()
     {
-        if (! $this->request->hasHeader('Authorization')) {
+        if (! request()->hasHeader('Authorization')) {
             return null;
         }
 
         try {
             // Attempt to parse and validate the JWT
-            $jwt = $this->request->bearerToken();
+            $jwt = request()->bearerToken();
             $token = (new Parser())->parse($jwt);
             if (! $token->verify(new Sha256(), file_get_contents($this->publicKey))) {
                 throw new AccessDeniedException(

--- a/src/Server/Token.php
+++ b/src/Server/Token.php
@@ -114,7 +114,6 @@ class Token
      */
     public function jwt()
     {
-
         $token = $this->parseToken();
 
         return $token ? (string) $token : null;

--- a/src/Testing/WithOAuthTokens.php
+++ b/src/Testing/WithOAuthTokens.php
@@ -70,6 +70,9 @@ trait WithOAuthTokens
             ->sign(new Sha256(), new Key('file://' . $privateKey))
             ->getToken();
 
+        // If a user is already authenticated, reset the guard.
+        auth('api')->logout();
+
         // Attach the token to the request.
         $header = $this->transformHeadersToServerVars(['Authorization' => 'Bearer ' . (string) $token]);
         $this->serverVariables = array_merge($this->serverVariables, $header);

--- a/src/Testing/WithOAuthTokens.php
+++ b/src/Testing/WithOAuthTokens.php
@@ -70,16 +70,16 @@ trait WithOAuthTokens
             ->sign(new Sha256(), new Key('file://' . $privateKey))
             ->getToken();
 
+        // Use the bundled public key for verifying test tokens.
+        config(['auth.providers.northstar.key' => dirname(__FILE__) . '/example-public.key']);
+        config(['services.northstar.key' => dirname(__FILE__) . '/example-public.key']);
+
         // If a user is already authenticated, reset the guard.
         auth('api')->logout();
 
         // Attach the token to the request.
         $header = $this->transformHeadersToServerVars(['Authorization' => 'Bearer ' . (string) $token]);
         $this->serverVariables = array_merge($this->serverVariables, $header);
-
-        // Use the bundled public key for verifying test tokens.
-        config(['auth.providers.northstar.key' => dirname(__FILE__) . '/example-public.key']);
-        config(['services.northstar.key' => dirname(__FILE__) . '/example-public.key']);
 
         return $this;
     }

--- a/tests/Server/Middleware/RequireRoleTest.php
+++ b/tests/Server/Middleware/RequireRoleTest.php
@@ -10,14 +10,11 @@ class RequireRoleTest extends TestCase
     /** @test */
     public function testNoToken()
     {
-        // @TODO: We need app() helper available in tests.
-        $this->markTestIncomplete();
-
         $this->setExpectedException(AccessDeniedHttpException::class);
 
         $request = $this->createRequest(null);
 
-        $middleware = new RequireRole(new Token($request, $this->key));
+        $middleware = new RequireRole(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, function () {
             // ...
         }, 'user');
@@ -26,16 +23,13 @@ class RequireRoleTest extends TestCase
     /** @test */
     public function testTokenWithoutRole()
     {
-        // @TODO: We need app() helper available in tests.
-        $this->markTestIncomplete();
-
         $this->setExpectedException(AccessDeniedHttpException::class);
 
         $request = $this->createJwtRequest($this->signer, 'phpunit', new Carbon('-10 minutes'), [
             'role' => 'user',
         ]);
 
-        $middleware = new RequireRole(new Token($request, $this->key));
+        $middleware = new RequireRole(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, function () {
             // ...
         }, 'admin');
@@ -44,9 +38,6 @@ class RequireRoleTest extends TestCase
     /** @test */
     public function testTokenWithRole()
     {
-        // @TODO: We need app() helper available in tests.
-        $this->markTestIncomplete();
-
         // We can use $next & $passed as a spy here.
         $passed = false;
         $next = function () use (&$passed) {
@@ -57,7 +48,7 @@ class RequireRoleTest extends TestCase
             'role' => 'admin',
         ]);
 
-        $middleware = new RequireRole(new Token($request, $this->key));
+        $middleware = new RequireRole(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, $next, 'admin');
 
         $this->assertTrue($passed);
@@ -66,9 +57,6 @@ class RequireRoleTest extends TestCase
     /** @test */
     public function testTokenWithMultipleRoles()
     {
-        // @TODO: We need app() helper available in tests.
-        $this->markTestIncomplete();
-
         // We can use $next & $passed as a spy here.
         $passed = false;
         $next = function () use (&$passed) {
@@ -79,7 +67,7 @@ class RequireRoleTest extends TestCase
             'role' => 'staff',
         ]);
 
-        $middleware = new RequireRole(new Token($request, $this->key));
+        $middleware = new RequireRole(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, $next, 'admin', 'staff');
 
         $this->assertTrue($passed);

--- a/tests/Server/Middleware/RequireScopeTest.php
+++ b/tests/Server/Middleware/RequireScopeTest.php
@@ -18,7 +18,7 @@ class RequireScopeTest extends TestCase
 
         $request = $this->createRequest(null);
 
-        $middleware = new RequireScope(new Token($request, $this->key));
+        $middleware = new RequireScope(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, $next, 'user');
 
         // Since we don't have a token on the request, this should still pass!
@@ -34,7 +34,7 @@ class RequireScopeTest extends TestCase
             'scopes' => [],
         ]);
 
-        $middleware = new RequireScope(new Token($request, $this->key));
+        $middleware = new RequireScope(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, function () {
             // ...
         }, 'user');
@@ -53,7 +53,7 @@ class RequireScopeTest extends TestCase
             'scopes' => ['user'],
         ]);
 
-        $middleware = new RequireScope(new Token($request, $this->key));
+        $middleware = new RequireScope(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, $next, 'user');
 
         $this->assertTrue($passed);
@@ -72,7 +72,7 @@ class RequireScopeTest extends TestCase
             'scopes' => ['user', 'dog', 'cat', 'puppet'],
         ]);
 
-        $middleware = new RequireScope(new Token($request, $this->key));
+        $middleware = new RequireScope(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, $next, 'user', 'puppet');
 
         $this->assertTrue($passed);

--- a/tests/Server/Middleware/RequireUserTest.php
+++ b/tests/Server/Middleware/RequireUserTest.php
@@ -14,7 +14,7 @@ class RequireUserTest extends TestCase
 
         $request = $this->createRequest(null);
 
-        $middleware = new RequireUser(new Token($request, $this->key));
+        $middleware = new RequireUser(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, function () {
             // ...
         });
@@ -27,7 +27,7 @@ class RequireUserTest extends TestCase
 
         $request = $this->createJwtRequest($this->signer, 'phpunit', new Carbon('-10 minutes'));
 
-        $middleware = new RequireUser(new Token($request, $this->key));
+        $middleware = new RequireUser(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, function () {
             // ...
         });
@@ -46,7 +46,7 @@ class RequireUserTest extends TestCase
             'sub' => '5543dfd6469c64ec7d8b46b3',
         ]);
 
-        $middleware = new RequireUser(new Token($request, $this->key));
+        $middleware = new RequireUser(new Token(new TestRequestHandler($request), $this->key));
         $middleware->handle($request, $next);
 
         $this->assertTrue($passed);

--- a/tests/Server/TestRequestHandler.php
+++ b/tests/Server/TestRequestHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+use DoSomething\Gateway\Server\RequestHandlerContract;
+
+class TestRequestHandler implements RequestHandlerContract
+{
+    /**
+     * The mocked web request.
+     */
+    protected $request;
+
+    /**
+     * Create a new test handler.
+     */
+    public function __construct($request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Return the mocked web request.
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+}

--- a/tests/Server/TokenTest.php
+++ b/tests/Server/TokenTest.php
@@ -10,7 +10,7 @@ class TokenTest extends TestCase
     public function testNoToken()
     {
         $request = $this->createRequest(null);
-        $token = new Token($request, $this->key);
+        $token = new Token(new TestRequestHandler($request), $this->key);
 
         $this->assertFalse($token->exists());
     }
@@ -19,7 +19,7 @@ class TokenTest extends TestCase
     public function testInvalidToken()
     {
         $request = $this->createRequest('Bearer nah');
-        $token = new Token($request, $this->key);
+        $token = new Token(new TestRequestHandler($request), $this->key);
 
         $this->setExpectedException(AccessDeniedException::class);
         $token->exists(); // throws!
@@ -31,7 +31,7 @@ class TokenTest extends TestCase
         $request = $this->createJwtRequest($this->signer, 'phpunit', new Carbon('9/14/2017 4:00pm'), []);
 
         $this->mockTime('9/14/2017 7:00pm');
-        $token = new Token($request, $this->key);
+        $token = new Token(new TestRequestHandler($request), $this->key);
 
         $this->setExpectedException(AccessDeniedException::class);
         $token->exists(); // throws!
@@ -44,7 +44,7 @@ class TokenTest extends TestCase
         $request = $this->createJwtRequest($other, 'phpunit', new Carbon('9/14/2017 4:00pm'), []);
 
         $this->mockTime('9/14/2017 4:10pm');
-        $token = new Token($request, $this->key);
+        $token = new Token(new TestRequestHandler($request), $this->key);
 
         $this->setExpectedException(AccessDeniedException::class);
         $token->exists(); // throws!
@@ -58,7 +58,7 @@ class TokenTest extends TestCase
         ]);
 
         $this->mockTime('9/14/2017 4:00pm');
-        $token = new Token($request, $this->key);
+        $token = new Token(new TestRequestHandler($request), $this->key);
 
         $this->assertTrue($token->exists());
         $this->assertEquals('phpunit', $token->client);
@@ -77,7 +77,7 @@ class TokenTest extends TestCase
         ]);
 
         $this->mockTime('9/14/2017 4:00pm');
-        $token = new Token($request, $this->key);
+        $token = new Token(new TestRequestHandler($request), $this->key);
 
         $this->assertTrue($token->exists());
         $this->assertEquals('phpunit', $token->client);


### PR DESCRIPTION
### What's this PR do?
Adds `logout` function to Gateway guard so we can make multiple API requests with different tokens/users in unit tests (needed in this [Rogue PR](https://github.com/DoSomething/rogue/pull/697)!).

### How should this be reviewed?
👀 

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
