### PR TITLE
remove logging of full api uri

### DIFF
--- a/src/ForwardsTransactionIds.php
+++ b/src/ForwardsTransactionIds.php
@@ -29,7 +29,6 @@ trait ForwardsTransactionIds
         if (! empty($this->logger)) {
             $this->logger->info('Request made.', [
                 'method' => $method,
-                'uri' => $this->getBaseUri() . $path,
                 'request_id' => $options['headers']['X-Request-ID'],
             ]);
         }

--- a/src/ForwardsTransactionIds.php
+++ b/src/ForwardsTransactionIds.php
@@ -24,13 +24,5 @@ trait ForwardsTransactionIds
         $options['headers'] = array_merge($options['headers'], [
             'X-Request-ID' => $transactionId,
         ]);
-
-        // If we have a logger, write details to the log.
-        if (! empty($this->logger)) {
-            $this->logger->info('Request made.', [
-                'method' => $method,
-                'request_id' => $options['headers']['X-Request-ID'],
-            ]);
-        }
     }
 }

--- a/tests/Traits/ForwardsTransactionIdsTest.php
+++ b/tests/Traits/ForwardsTransactionIdsTest.php
@@ -31,8 +31,5 @@ class ForwardsTransactionIdsTest extends TestCase
 
         // We should see the existing `X-Request-Id` on the request.
         $this->assertEquals([$requestId], $client->getLastRequest()->getHeader('X-Request-ID'));
-
-        // And we should have written an entry to the log.
-        $logger->shouldHaveReceived('info')->once()->with('Request made.', Mockery::any());
     }
 }


### PR DESCRIPTION
### What's this PR do?

Removes logging the full base URI each time a request is made through gateway. This uri could contain PII, if stuff like email or phone number are included in the request (like in northstar requests)

### How should this be reviewed

👀 

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
