### PR TITLE
Northstar resets

### DIFF
--- a/src/Northstar.php
+++ b/src/Northstar.php
@@ -125,6 +125,18 @@ class Northstar extends RestApiClient
     }
 
     /**
+     * Executes a POST request to send user a password reset email.
+     *
+     * @param string $id - Northstar User ID.
+     * @param string $type - The type of password reset email to send.
+     * @return array - key/value array of Northstar response.
+     */
+    public function sendUserPasswordReset($id, $type)
+    {
+        return $this->post('v2/resets', ['id' => $id, 'type' => $type]);
+    }
+
+    /**
      * Send a GET request to return all Northstar keys.
      * Requires an `admin` scoped API key.
      *

--- a/tests/NorthstarTest.php
+++ b/tests/NorthstarTest.php
@@ -143,4 +143,22 @@ class NorthstarTest extends TestCase
 
         $this->assertEquals('Katherine', $response->first_name);
     }
+
+    /**
+     * Test that we can send a user a password reset.
+     */
+    public function testSendUserPasswordReset()
+    {
+        $restClient = new MockNorthstar($this->defaultConfig, [
+            new JwtResponse(),
+            new JsonResponse([
+                'success' => [
+                    'code' => 200,
+                ],
+            ]),
+        ]);
+
+        $response = $restClient->sendUserPasswordReset('5480c950ce5fbc2145eb7721', 'forgot-password');
+        $this->assertEquals($response['success'], ['code' => 200]);
+    }
 }


### PR DESCRIPTION
### What's this PR do?

Adds a `sendUserPasswordReset` function to execute post requests to the [Northstar `/v2/resets`  endpoint.](https://github.com/DoSomething/northstar/blob/master/documentation/endpoints/resets.md) This will be used to send emails for [non-traditional member activation](https://docs.google.com/document/d/1RbWAAJA-zTfQYv6dBVIcpJqegKJUM0dH4DkVpikRpE0/edit?ts=5c6f0bd1#heading=h.f68k8ccmho5).

### How should this be reviewed?
▶️ ✉️ 

### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Is this a [breaking change](http://semver.org)? -- no
