### PR TITLE
Add support for requesting optional fields.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,0 @@
-# Code Owners <https://git.io/vFXjf>
-# ==================================
-# This will automatically request the following users to review
-# pull requests made on this repository.
-
-*       @dfurnes @weerd

--- a/src/Northstar.php
+++ b/src/Northstar.php
@@ -51,11 +51,13 @@ class Northstar extends RestApiClient
      * Send a GET request to return a user with that id.
      *
      * @param string $id
+     * @param array $fields - optional fields to request
      * @return NorthstarUser
      */
-    public function getUser($id)
+    public function getUser($id, $fields = null)
     {
-        $response = $this->get('v2/users/'.$id);
+        $include = $fields ? implode(',', $fields) : null;
+        $response = $this->get('v2/users/'.$id, ['include' => $include]);
 
         if (is_null($response)) {
             return null;


### PR DESCRIPTION
### What's this PR do?
This pull request adds the ability to request optional fields, like so:

```php
gateway('northstar')->getUser($id, ['last_name', 'birthdate']);
```

If omitted, no `?include=` query string will be appended.

### How should this be reviewed?
👀

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
