### PR TITLE
Add support for using OAuth on downstream requests with RemoteUser.

### DIFF
--- a/src/Server/RemoteAuthenticatable.php
+++ b/src/Server/RemoteAuthenticatable.php
@@ -3,6 +3,7 @@
 namespace DoSomething\Gateway\Server;
 
 use InvalidArgumentException;
+use League\OAuth2\Client\Token\AccessToken;
 
 trait RemoteAuthenticatable
 {
@@ -24,6 +25,22 @@ trait RemoteAuthenticatable
     public function getAuthIdentifier()
     {
         return $this->id;
+    }
+
+    /**
+     * Get the OAuth token for downstream requests.
+     *
+     * @return AccessToken
+     */
+    public function getOAuthToken()
+    {
+        return new AccessToken([
+            'resource_owner_id' => $this->getAuthIdentifier(),
+            'access_token' => token()->jwt(),
+            'refresh_token' => null,
+            'expires' => token()->expires()->timestamp,
+            'role' => token()->role(),
+        ]);
     }
 
     /**


### PR DESCRIPTION
### What's this PR do?
This pull request adds support for making downstream requests with the current "session" when using `RemoteUser` (the built-in "authenticatable" for requests made with JWTs in Gateway).

### How should this be reviewed?
This allows Gateway's API clients to [get the current token](https://github.com/DoSomething/gateway/blob/c4fd3db946985b14df6dafe64b89f789b7cfc440/src/AuthorizesWithOAuth2.php#L324) for requests made with JWTs (as opposed to a traditional session that'd be reading this from the database record).

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
