### PR TITLE
Fix old 'getUser' signature in RemoteUser.

### DIFF
--- a/docs/clients/Northstar.md
+++ b/docs/clients/Northstar.md
@@ -56,7 +56,7 @@ Responses are generally returned as `NorthstarUser` or `NorthstarClient` instanc
 ```php
 <?php
 
-$user = $northstar->getUser('id', '5480c950bffebc651c8b4570');
+$user = $northstar->getUser('5480c950bffebc651c8b4570');
 
 echo $user->created_at->diffForHumans(); // two years ago
 ```

--- a/src/Server/RemoteUser.php
+++ b/src/Server/RemoteUser.php
@@ -59,7 +59,7 @@ class RemoteUser implements Authenticatable
         // duration of this request. (This instance is kept by the
         // user provider.)
         if (! $this->loaded) {
-            $user = gateway('northstar')->withToken($this->token)->getUser('id', $this->id);
+            $user = gateway('northstar')->withToken($this->token)->getUser($this->id);
 
             $this->attributes = $user->toArray();
             $this->loaded = true;


### PR DESCRIPTION
### What's this PR do?
This includes a fix I'd missed in #126 to use the new `getUser` signature introduced in #125.

### How should this be reviewed?
🌵

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
