### PR TITLE
Fix issue using optional() on a RemoteUser in Laravel 5.6+.

### DIFF
--- a/src/Common/HasAttributes.php
+++ b/src/Common/HasAttributes.php
@@ -27,7 +27,7 @@ trait HasAttributes
      */
     public function __isset($key)
     {
-        return (isset($this->attributes[$key]) || isset($this->relations[$key])) ||
+        return isset($this->attributes[$key]) ||
         ($this->hasGetMutator($key) && ! is_null($this->getAttributeValue($key)));
     }
 

--- a/src/Server/RemoteUser.php
+++ b/src/Server/RemoteUser.php
@@ -59,10 +59,7 @@ class RemoteUser implements Authenticatable
         // duration of this request. (This instance is kept by the
         // user provider.)
         if (! $this->loaded) {
-            $user = gateway('northstar')->withToken($this->token)->getUser($this->id);
-
-            $this->attributes = $user->toArray();
-            $this->loaded = true;
+            $this->loadAttributes();
         }
 
         if (array_key_exists($key, $this->attributes) || $this->hasGetMutator($key)) {
@@ -70,5 +67,19 @@ class RemoteUser implements Authenticatable
         }
 
         return null;
+    }
+
+    /**
+     * Load the attributes on this 'RemoteUser' by requesting
+     * the corresponding user profile in Northstar.
+     *
+     * @return void
+     */
+    private function loadAttributes()
+    {
+        $user = gateway('northstar')->withToken($this->token)->getUser($this->id);
+
+        $this->attributes = $user->toArray();
+        $this->loaded = true;
     }
 }

--- a/src/Server/RemoteUser.php
+++ b/src/Server/RemoteUser.php
@@ -40,7 +40,7 @@ class RemoteUser implements Authenticatable
     }
 
     /**
-     * Is this attribute specified on the user? 
+     * Is this attribute specified on the user?
      *
      * @param  string  $key
      * @return bool

--- a/src/Server/RemoteUser.php
+++ b/src/Server/RemoteUser.php
@@ -40,6 +40,29 @@ class RemoteUser implements Authenticatable
     }
 
     /**
+     * Is this attribute specified on the user? 
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        // We read some fields directly from the OAuth token, and so
+        // they can always be considered "set" (even if they're null):
+        if (in_array($key, ['id', 'northstar_id', 'role'])) {
+            return true;
+        }
+
+        // Otherwise, we'll need to load the user's full user profile
+        // attributes & check if requested key is set there:
+        if (! $this->loaded) {
+            $this->loadAttributes();
+        }
+
+        return isset($this->attributes[$key]);
+    }
+
+    /**
      * Get an attribute, either from the token on the request or by
      * lazy-loading the full profile from the authorization server.
      *


### PR DESCRIPTION
### What's this PR do?
This pull request fixes an issue where checking `optional(auth()->user())->role` would throw an error in Laravel 5.6.

This started happening because Laravel 5.6's `optional` helper [now checks if the requested field is set](https://git.io/JJCZs) using the null-coalescing operator (which, behind the scenes runs an `isset()` check on that field). Because these fields aren't _really_ set on the `RemoteUser` class (which is just a convenience wrapper for accessing the token or Northstar user), it'd always be null!

### How should this be reviewed?
I extracted a `loadAttributes` method in 30b6141 so I could use it in this new `__isset` method, added in f302997.

I also cleaned up a reference to `$this->relations` from `HasAttributes` in 97016a7. I think this was mistakenly copy-pasted when I extracted this logic from Laravel's `HasAttributes` to use here.

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
