### PR TITLE
Switching from array helper to Arr class.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "phpunit/phpunit": "^8.0",
     "illuminate/database": "^6.0",
     "illuminate/http": "^6.0",
+    "illuminate/support": "^6.0",
     "symfony/var-dumper": "^4.4",
     "mockery/mockery": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "phpunit/phpunit": "^8.0",
     "illuminate/database": "^6.0",
     "illuminate/http": "^6.0",
-    "illuminate/support": "^6.0.0",
+    "illuminate/support": "^6.0",
     "symfony/var-dumper": "^4.4",
     "mockery/mockery": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "phpunit/phpunit": "^8.0",
     "illuminate/database": "^6.0",
     "illuminate/http": "^6.0",
-    "illuminate/support": "^6.0",
+    "illuminate/support": "^6.0.0",
     "symfony/var-dumper": "^4.4",
     "mockery/mockery": "^1.0"
   },

--- a/src/Testing/WithOAuthTokens.php
+++ b/src/Testing/WithOAuthTokens.php
@@ -4,6 +4,7 @@ namespace DoSomething\Gateway\Testing;
 
 use Carbon\Carbon;
 use Lcobucci\JWT\Builder;
+use Illuminate\Support\Arr;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 
@@ -14,7 +15,7 @@ trait WithOAuthTokens
 {
     protected function randomUserId()
     {
-        return array_random([
+        return Arr::random([
             '5554eac1a59dbf117e8b4567',
             '5570b6cea59dbf3b7a8b4567',
             '5575e568a59dbf3b7a8b4572',


### PR DESCRIPTION
### What's this PR do?
While working on updating DoSomething/Rogue from Laravel 5.8 to 6.0 I encountered a bunch of errors when running PHPUnit related to:

```
Tests\Http\CampaignTest::testCampaignCursor
Error: Call to undefined function DoSomething\Gateway\Testing\array_random()
```

The array and string helper functions were officially removed in Laravel 6.0 and we use the `array_random()` helper in our Gateway authentication trait. So best to update and use the new `Arr` class moving forward.

### How should this be reviewed?
…

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
