### PR TITLE
Upgrade dependencies for Laravel 8.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "symfony/psr-http-message-bridge": "^1.0",
     "laminas/laminas-diactoros": "^2.2",
     "gree/jose": "^2.2",
-    "ramsey/uuid": "^3.7"
+    "ramsey/uuid": "^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,13 @@
   "description": "Standard PHP API client for DoSomething.org services.",
   "require": {
     "nesbot/carbon": "^2.0",
-    "lcobucci/jwt": "^3.1",
+    "lcobucci/jwt": "~3.3.2",
     "guzzlehttp/guzzle": "^6.2|^7.0",
     "league/oauth2-client": "^2.2",
     "symfony/psr-http-message-bridge": "^1.0",
     "laminas/laminas-diactoros": "^2.2",
     "gree/jose": "^2.2",
-    "ramsey/uuid": "^4.0"
+    "ramsey/uuid": "^3.7|^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",
@@ -30,19 +30,23 @@
     "psr-4": {
       "DoSomething\\Gateway\\": "src/"
     },
-    "files": ["src/Laravel/helpers.php"]
+    "files": [
+      "src/Laravel/helpers.php"
+    ]
   },
   "autoload-dev": {
-    "classmap": ["tests/TestCase.php"],
+    "classmap": [
+      "tests/TestCase.php"
+    ],
     "psr-4": {
       "DoSomething\\GatewayTests\\": "tests/"
     }
   },
   "extra": {
     "laravel": {
-        "providers": [
-            "DoSomething\\Gateway\\Laravel\\GatewayServiceProvider"
-        ]
+      "providers": [
+        "DoSomething\\Gateway\\Laravel\\GatewayServiceProvider"
+      ]
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "require": {
     "nesbot/carbon": "^2.0",
     "lcobucci/jwt": "^3.1",
-    "guzzlehttp/guzzle": "^6.2",
+    "guzzlehttp/guzzle": "^6.2|^7.0",
     "league/oauth2-client": "^2.2",
     "symfony/psr-http-message-bridge": "^1.0",
     "laminas/laminas-diactoros": "^2.2",


### PR DESCRIPTION
### What's this PR do?
This pull request allows Gateway to use updated [Guzzle](https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#60-to-70) and [`ramsey/uuid`](https://github.com/ramsey/uuid/releases/tag/4.0.0) dependencies (for Laravel 8).

### How should this be reviewed?
From what I can tell, the breaking changes in the Guzzle & UUID packages (linked above) should not affect the way we use these packages, so it's safe to use either major version release. There _are_ [breaking changes](https://lcobucci-jwt.readthedocs.io/en/stable/upgrading/) in the minor 3.4.x release of `lcobucci/jwt`, which I've pinned [as we do in Northstar](https://github.com/DoSomething/northstar/blob/e9fb91efd8f5c4fec5feac94643eafe3f24bafbd/composer.json#L13).

Since we can safely allow either version of these packages, we can safely release this as a minor version bump.

We can revisit upgrading `lcobucci/jwt` to 3.4 and/or 4.0 in a future (major) release of this package!

### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Is this a [breaking change](http://semver.org)?
